### PR TITLE
Conditional import to address duplicated analytics

### DIFF
--- a/acrobat/blocks/unity/unity.js
+++ b/acrobat/blocks/unity/unity.js
@@ -1,6 +1,4 @@
-import { LIMITS as VERB_WIDGET_LIMITS } from '../verb-widget/verb-widget.js';
-
-const LIMITS = { ...VERB_WIDGET_LIMITS };
+const LIMITS = {};
 
 export const localeMap = {
   '': 'en-us',
@@ -115,11 +113,13 @@ export default async function init(el) {
   const element = el.querySelector('span');
   const verbWidget = el.closest('.section')?.querySelector('.verb-widget');
   const studyMarquee = el.closest('.section')?.querySelector('.study-marquee');
+  if (verbWidget) {
+    const { LIMITS: VERB_WIDGET_LIMITS } = await import('../verb-widget/verb-widget.js');
+    Object.assign(LIMITS, VERB_WIDGET_LIMITS);
+  }
   if (studyMarquee) {
     const { LIMITS: STUDY_MARQUEE_LIMITS } = await import('../study-marquee/study-marquee.js');
-    Object.entries(STUDY_MARQUEE_LIMITS).forEach(([key, val]) => {
-      LIMITS[key] = val;
-    });
+    Object.assign(LIMITS, STUDY_MARQUEE_LIMITS);
   }
   const widgetBlock = verbWidget || studyMarquee;
   const verb = (widgetBlock && [...widgetBlock.classList].find((cn) => LIMITS[cn])) || element.classList[1].replace('icon-', '');

--- a/acrobat/blocks/unity/unity.js
+++ b/acrobat/blocks/unity/unity.js
@@ -1,7 +1,6 @@
 import { LIMITS as VERB_WIDGET_LIMITS } from '../verb-widget/verb-widget.js';
-import { LIMITS as STUDY_MARQUEE_LIMITS } from '../study-marquee/study-marquee.js';
 
-const LIMITS = { ...VERB_WIDGET_LIMITS, ...STUDY_MARQUEE_LIMITS };
+const LIMITS = { ...VERB_WIDGET_LIMITS };
 
 export const localeMap = {
   '': 'en-us',
@@ -116,6 +115,12 @@ export default async function init(el) {
   const element = el.querySelector('span');
   const verbWidget = el.closest('.section')?.querySelector('.verb-widget');
   const studyMarquee = el.closest('.section')?.querySelector('.study-marquee');
+  if (studyMarquee) {
+    const { LIMITS: STUDY_MARQUEE_LIMITS } = await import('../study-marquee/study-marquee.js');
+    Object.entries(STUDY_MARQUEE_LIMITS).forEach(([key, val]) => {
+      LIMITS[key] = val;
+    });
+  }
   const widgetBlock = verbWidget || studyMarquee;
   const verb = (widgetBlock && [...widgetBlock.classList].find((cn) => LIMITS[cn])) || element.classList[1].replace('icon-', '');
   if (mobileApp && LIMITS[verb]?.mobileApp) return;


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Import study-marquee and verb-widget dependencies conditionally in unity.js. More proper refactoring of these files will be in the backlog.

## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: https://jira.corp.adobe.com/browse/MWPW-190811

## Test URLs
<!-- List the URLs where the changes can be tested -->
- https://stage--da-dc--adobecom.aem.live/acrobat/online/jpg-to-pdf
- https://study-marquee-analytics--da-dc--adobecom.aem.live/acrobat/online/jpg-to-pdf

Before: study-marquee.js is loaded on a page not using study-marquee
<img width="2035" height="717" alt="Screenshot 2026-03-23 at 14 38 47" src="https://github.com/user-attachments/assets/c9930a99-bb28-4f57-9ef9-a069e6843a36" />


After: no study-marquee.js should be loaded on a page not using study-marquee
<img width="2012" height="806" alt="Screenshot 2026-03-23 at 14 37 58" src="https://github.com/user-attachments/assets/784d5ae8-454d-46c5-bc92-79bf81163e96" />


Note:
This code has also been synched to ims branch, so we can verify unity flow on https://ims--da-dc--adobecom.aem.live/acrobat/online/jpg-to-pdf and https://ims--da-dc--adobecom.aem.page/acrobat/online/quiz-maker. These pages should not be affected