### PR TITLE
[Tokowaka] Exclude adobeedgeoptimize from old browser list

### DIFF
--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -57,6 +57,10 @@ const getBrowserData = (userAgent) => {
   if (!userAgent) {
     return {};
   }
+  if (userAgent.includes('AdobeEdgeOptimize')) {
+    return { ua: userAgent, isMobile: false };
+  }
+
   const browser = {
     ua: userAgent,
     isMobile: userAgent.includes('Mobile'),


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Exclude a mocked UA from being considered old. Should have 0 impact on any live page to real visitors.

## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: https://jira.corp.adobe.com/browse/MWPW-191384

## Test URLs
<!-- List the URLs where the changes can be tested -->
- https://stage--da-dc--adobecom.aem.live/acrobat/online/compress-pdf
- https://tokowaka-browser--da-dc--adobecom.aem.live/acrobat/online/compress-pdf?martech=off

## How to test
- Create a custom UA with UA string being `AdobeEdgeOptimize-AI Tokowaka/1.0 AdobeEdgeOptimize/1.0`
- In stage, it should redirect to a "use another browser" page. In this feature branch, it should load the page normally