### PR TITLE
MWPW-188278: Align head-loaded SSR flag with da-bacom pattern

### DIFF
--- a/head.html
+++ b/head.html
@@ -1,4 +1,5 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="head-loaded" content="false" />
 <link rel="preconnect" href="https://acrobat.adobe.com" crossorigin>
 <script src="/acrobat/scripts/scripts.js" type="module"></script>
 <style>body { display: none; }</style>
@@ -76,7 +77,8 @@
   const userAgentString = window.navigator.userAgent;
   const isAllowedAgent = allowedAgents && allowedAgents.some((agent) => userAgentString.includes(agent.trim()));
 
-  const ssrFlag = document.querySelector('meta[name="head-loaded"]');
+  const flagMeta = document.querySelector('meta[name="head-loaded"]');
+  const ssrFlag = flagMeta?.content === 'true';
   const LOCALES = ['ae_ar', 'ae_en', 'africa', 'ar', 'at', 'au', 'be_en', 'be_fr', 'be_nl', 'bg', 'br', 'ca_fr', 'ca', 'ch_de', 'ch_fr', 'ch_it', 'cl', 'cn', 'co', 'cr', 'cy_en', 'cz', 'de', 'dk', 'ec', 'ee', 'eg_ar', 'eg_en', 'el', 'es', 'fi', 'fr', 'gr_el', 'gr_en', 'gt', 'hk_en', 'hk_zh', 'hu', 'id_en', 'id_id', 'ie', 'il_en', 'il_he', 'in_hi', 'in', 'it', 'jp', 'kr', 'kw_ar', 'kw_en', 'la', 'lt', 'lu_de', 'lu_en', 'lu_fr', 'lv', 'mena_ar', 'mena_en', 'mt', 'mx', 'my_en', 'my_ms', 'ng', 'nl', 'no', 'nz', 'pe', 'ph_en', 'ph_fil', 'pl', 'pr', 'pt', 'qa_ar', 'qa_en', 'ro', 'ru', 'sa_ar', 'sa_en', 'se', 'sg', 'si', 'sk', 'th_en', 'th_th', 'tr', 'tw', 'ua', 'uk', 'vn_en', 'vn_vi', 'za'];
 
   (() => {
@@ -166,8 +168,6 @@
       fetchAndParseSitemap();
     }
   })();
-  
-  const meta = document.createElement('meta');
-  meta.setAttribute('name', 'head-loaded');
-  document.head.append(meta);
+
+  flagMeta.content = 'true';
 </script>


### PR DESCRIPTION
* Adds a meta element that will have it's content modified at the end of the script tag. When content is served with server side rendering from tokowaka, it will prevent any duplication that would occur should the script be run again, like when spoofing headers in the browser. 

Resolves: [MWPW-188278](https://jira.corp.adobe.com/browse/MWPW-188278)

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.live/acrobat/online/compress-pdf
- After: https://ssr-flag--da-dc--adobecom.aem.live/acrobat/online/compress-pdf

## Verification Steps

- Go to the test page
- Inspect the `<head>` element, notice no new links
- Go to the network tab
- Click on "More network conditions"
- Scroll down and enable "Custom User Agent" 
- Enter: "ChatGPT-User"
- Reload
- Inspect the `<head>`
- Notice links 
- Ensure there is no link duplication

## Additional testing example with video:
https://wiki.corp.adobe.com/spaces/WP4/pages/3747684013/Adding+Hreflang+Link+Block+Functionality#AddingHreflangLinkBlockFunctionality-Testing

## Implementation doc
https://wiki.corp.adobe.com/spaces/WP4/pages/3747684013/Adding+Hreflang+Link+Block+Functionality