### PR TITLE
Add study-marquee support and acrobat.adobe.com subdomain routing

### DIFF
--- a/edgeworkers/Acrobat_DC_web_prod/main.js
+++ b/edgeworkers/Acrobat_DC_web_prod/main.js
@@ -275,11 +275,7 @@ async function frictionlessResponseProvider(request) {
   const fetchFrictionlessPage = async () => {
     // Setup: Fetch a stream containing HTML
     const path = `${origin}${request.path}`;
-    const headers = {'X-EW-Frictionless-Page': ['true']};
-    const htmlResponse = await httpRequest(
-      path,
-      {headers},
-    );
+    const htmlResponse = await httpRequest(path);
     if (!htmlResponse.ok) {
       const err = new Error(`Failed to fetch doc: ${path}`);
       err.body = htmlResponse.body;
@@ -416,7 +412,7 @@ async function frictionlessResponseProvider(request) {
   };
 
   try {
-    const miloBaseUrl = isProd ? 'https://milo.adobe.com' : 'https://milo.stage.adobe.com';
+    const miloBaseUrl = '/dc-shared';
     const [
       [responseStream, responseHeaders, mobileWidget, unityWorkflow],
       scripts,
@@ -443,7 +439,6 @@ async function frictionlessResponseProvider(request) {
         `<${adobeid}>;rel="preconnect"`,
         '<https://assets.adobedtm.com>;rel="preconnect"',
         '<https://use.typekit.net>;rel="preconnect"',
-        `<${miloBaseUrl}>;rel="preconnect"`,
         `<${miloBaseUrl}/libs/deps/imslib.min.js>;rel="preload";as="script"`,
     ];
     if (unityWorkflow) {

--- a/edgeworkers/Acrobat_DC_web_prod/main.js
+++ b/edgeworkers/Acrobat_DC_web_prod/main.js
@@ -11,6 +11,9 @@ import verbMap from './utils/verbs.js';
 import contentSecurityPolicy from './utils/csp/index.js';
 
 export async function responseProvider(request) {
+  if (['acrobat.adobe.com','stage.acrobat.adobe.com'].includes(request.host)) {
+    return frictionlessResponseProvider(request);
+  }
   const path = request.path.split('/');
   const first = path[1];
   const locale = localeMap[first];
@@ -239,6 +242,220 @@ export async function responseProvider(request) {
         `<${pdfnow}>;rel="preconnect"`,
         `<${acrobat}/dc-core/${dcCoreVersion}/dc-core.js>;rel="preload";as="script"`,
         `<${acrobat}/dc-core/${dcCoreVersion}/dc-core.css>;rel="preload";as="style"`,
+      ];
+    }
+    headerLink = headerLink.join();
+
+    const headers = {
+      ...responseHeaders,
+      'Content-Security-Policy': csp,
+      Link: headerLink
+    };
+
+    return createResponse(
+      200,
+      headers,
+      responseStream.pipeThrough(rewriter),
+    );
+  } catch (error) {
+    return createResponse(error.status ?? 500, {}, error.body ?? error.message);
+  }
+}
+
+async function frictionlessResponseProvider(request) {
+  const path = request.path.split('/');
+  const first = path[1];
+  const last = path.splice(-1)[0].split('.')[0];
+  const origin = `${request.scheme}://${request.host}`;
+  const isProd = request.host === 'acrobat.adobe.com';
+  const codeRoot = '/dc-shared';
+  const contentRoot = '/dc-shared';
+  const rewriter = new HtmlRewritingStream();
+
+  const fetchFrictionlessPage = async () => {
+    // Setup: Fetch a stream containing HTML
+    const path = `${origin}${request.path}`;
+    const headers = {'X-EW-Frictionless-Page': ['true']};
+    const htmlResponse = await httpRequest(
+      path,
+      {headers},
+    );
+    if (!htmlResponse.ok) {
+      const err = new Error(`Failed to fetch doc: ${path}`);
+      err.body = htmlResponse.body;
+      err.status = htmlResponse.status;
+      throw err;
+    }
+
+    // Make preliminary pass through the content to capture metadata
+    const firstPassRewriter = new HtmlRewritingStream();
+    let mobileWidget, unityWorkflow;
+    firstPassRewriter.onElement('meta[name="mobile-widget"]', el => {
+      mobileWidget = el.getAttribute('content');
+    });
+    firstPassRewriter.onElement('.unity.workflow-acrobat', el => {
+      unityWorkflow = true;
+    });    
+    const nullWriter = new WritableStream({
+      write() {},
+      close() {},
+    });
+
+    const [preParseStream, responseStream] = htmlResponse.body.tee();
+    await preParseStream.pipeThrough(firstPassRewriter).pipeTo(nullWriter);
+
+    // Strip headers which should not be forwarded
+    const responseHeaders = htmlResponse.getHeaders();
+    for (const prop of [
+      'accept-encoding',
+      'cache-control',
+      'content-encoding',
+      'content-length',
+      'connection',
+      'keep-alive',
+      'link',
+      'proxy-authenticate',
+      'proxy-authorization',
+      'te',
+      'trailers',
+      'transfer-encoding',
+      'upgrade',
+      'vary',
+    ]) {
+      delete responseHeaders[prop];
+    }
+
+    return [responseStream, responseHeaders, mobileWidget, unityWorkflow];
+  };
+
+  const fetchResource = async path => {
+    const url = path.startsWith('http') ? path : origin + path;
+    const response = await httpRequest(url);
+    if (response.ok) {
+      return response.text();
+    }
+    const statusText = response.statusText || 'Unknown';
+    throw new Error(
+      `fetchResource failed | path: "${path}" | url: "${url}" | status: ${response.status} (${statusText})`
+    );
+  };
+
+  const scriptHashes = [];
+  let prerenderTop = 0;
+
+  const inlineScripts = async (unityWorkflow, mobileWidget, scripts, dcConverter) => {
+    // Inline dc-converter-widget.js and scripts.js. Remove modular definition and import.
+    // Change relative paths to absolute. Remove JS-driven CSP in favor of HTTP header.
+    let inlineScript = scripts
+      .replace('await import(\'./contentSecurityPolicy/csp.js\')', '{default:()=>{}}')
+      .replace('await import(\'./dcLana.js\')', `await import('${codeRoot}/scripts/dcLana.js')`)
+      .replace('await import(\'./susiAuthHandler.js\')', `await import('${codeRoot}/scripts/susiAuthHandler.js')`)
+      .replace('await import(\'./geo-phoneNumber.js\')', `await import('${codeRoot}/scripts/geo-phoneNumber.js')`)
+      .replace('await import(\'./tooltips.js\')', `await import('${codeRoot}/scripts/tooltips.js')`)
+      .replace('await import(\'./imageReplacer.js\')', `await import('${codeRoot}/scripts/imageReplacer.js')`);
+
+    if (!(mobileWidget && request.device.isMobile) && !unityWorkflow) {
+      inlineScript = dcConverter
+        .replace('export default', 'const dcConverter = ')
+        .replace('import(\'../../scripts/frictionless.js\')', `import('${codeRoot}/scripts/frictionless.js')`)
+      + inlineScript
+        .replace('const { default: dcConverter } = await import(`../blocks/${blockName}/${blockName}.js`);', '')
+    } 
+
+    // Generate hash of inlined script and add to our CSP policy
+    const hash = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(inlineScript));
+    const hash64 = btoa(String.fromCharCode(...new Uint8Array(hash)));
+    scriptHashes.push(`'sha256-${hash64}'`);
+
+    const headers = request.getHeaders();
+    const ua = headers["user-agent"][0];
+    const isMobile = /android|iphone|ipod|blackberry|windows phone/i.test(ua);
+    const isIPadOS = ua.includes('Mac') && ua.includes('Version/') && !/iphone|ipod/i.test(ua);
+    const isTablet = /ipad|android(?!.*mobile)/i.test(ua);    
+    if (unityWorkflow && !(isTablet || isIPadOS)) {
+      const group = 'frictionless_acrobat' + `${path.filter(Boolean).length <= 1 ? '' : `_${first}`}`;
+      const edgeKv = new EdgeKV({namespace: isProd? 'prod' : 'stage', group});
+      let prerenderHtml = '<!-- init -->';
+      try {
+        const item = last + ((isMobile || isIPadOS || isTablet) ? '_mobile' : '_desktop');
+        const prerenderJson = await edgeKv.getJson({ item, default_value: {html: '', top: 0} });
+        prerenderHtml = prerenderJson.html;
+        prerenderTop = prerenderJson.top;
+        if (prerenderHtml) {
+          prerenderHtml = `<div id="prerender_verb-widget">${prerenderHtml}</div>`;
+        }
+      } catch (e) {
+        prerenderHtml = `<!-- ${e.toString()} -->`;
+      }
+
+      rewriter.onElement('body', el => {
+        el.prepend(prerenderHtml);
+      });
+    }
+
+    // Remove external script reference
+    rewriter.onElement(`script[src="${codeRoot}/scripts/scripts.js"]`, el => {
+      el.replaceWith('');
+    });
+    // Can't put scripts.js in HEAD, loadPage needs the BODY to be parsed.
+    rewriter.onElement('body', el => {
+      // TODO: Make more explicit markers in code
+      el.append(`<script>${inlineScript}</script>`);
+    });
+  };
+
+  const inlineStyles = (dcStyles, miloStyles, verbWidgetStyles, unityWorkflow, prerenderTop) => {
+    rewriter.onElement('head', el => {
+      el.append(`<style id="inline-milo-styles">${miloStyles}</style>`);
+      el.append(`<style id="inline-dc-styles">${dcStyles}</style>`);
+      if (unityWorkflow) {
+        el.append(`<style id="inline-verb-widget-styles">${verbWidgetStyles}</style>`);
+        el.append(`<style>#prerender_verb-widget { position: absolute; top: ${prerenderTop}; left: 0; width: 100%; z-index: -1; pointer-events: auto; }</style></head>`);
+      }
+    });
+  };
+
+  try {
+    const miloBaseUrl = isProd ? 'https://milo.adobe.com' : 'https://milo.stage.adobe.com';
+    const [
+      [responseStream, responseHeaders, mobileWidget, unityWorkflow],
+      scripts,
+      dcConverter,
+      dcStyles,
+      miloStyles,
+      verbWidgetStyles
+    ] = await Promise.all([
+      fetchFrictionlessPage(),
+      fetchResource(`${codeRoot}/scripts/scripts.js`),
+      fetchResource(`${codeRoot}/blocks/dc-converter-widget/dc-converter-widget.js`),
+      fetchResource(`${codeRoot}/styles/styles.css`),
+      fetchResource(`${miloBaseUrl}/libs/styles/styles.css`),
+      fetchResource(`${codeRoot}/blocks/verb-widget/verb-widget.css`)
+    ]);
+
+    await inlineScripts(unityWorkflow, mobileWidget, scripts, dcConverter);
+    inlineStyles(dcStyles, miloStyles, verbWidgetStyles, unityWorkflow, prerenderTop);
+
+    const csp = contentSecurityPolicy(isProd, scriptHashes);
+    const adobeid = isProd ? 'https://adobeid-na1.services.adobe.com' : 'https://adobeid-na1-stg1.services.adobe.com';
+
+    let headerLink = [
+        `<${adobeid}>;rel="preconnect"`,
+        '<https://assets.adobedtm.com>;rel="preconnect"',
+        '<https://use.typekit.net>;rel="preconnect"',
+        `<${miloBaseUrl}>;rel="preconnect"`,
+        `<${miloBaseUrl}/libs/deps/imslib.min.js>;rel="preload";as="script"`,
+    ];
+    if (unityWorkflow) {
+      headerLink = [...headerLink,
+        `<${codeRoot}/blocks/unity/unity.js>;rel="preload";as="script";crossorigin="anonymous"`,
+        `<${codeRoot}/blocks/unity/unity.css>;rel="preload";as="style"`,
+        `<${codeRoot}/blocks/verb-widget/verb-widget.js>;rel="preload";as="script";crossorigin="anonymous"`,
+        `<${codeRoot}/blocks/verb-widget/verb-widget.css>;rel="preload";as="style"`,
+        `<${codeRoot}/scripts/utils.js>;rel="preload";as="script";crossorigin="anonymous"`,
+        `<${miloBaseUrl}/libs/utils/utils.js>;rel="preload";as="script";crossorigin="anonymous"`,
+        `<${miloBaseUrl}/libs/features/placeholders.js>;rel="preload";as="script";crossorigin="anonymous"`,
+        `<${path.filter(Boolean).length <= 1 ? '' : `/${first}`}${contentRoot}/placeholders.json>;rel="preload";as="fetch";crossorigin="anonymous"`
       ];
     }
     headerLink = headerLink.join();

--- a/edgeworkers/Acrobat_DC_web_prod/main.js
+++ b/edgeworkers/Acrobat_DC_web_prod/main.js
@@ -50,7 +50,11 @@ export async function responseProvider(request) {
     });
     firstPassRewriter.onElement('.unity.workflow-acrobat', el => {
       unityWorkflow = true;
-    });    
+    });
+    let studyMarquee;
+    firstPassRewriter.onElement('.study-marquee', el => {
+      studyMarquee = true;
+    });
     const nullWriter = new WritableStream({
       write() {},
       close() {},
@@ -80,7 +84,7 @@ export async function responseProvider(request) {
       delete responseHeaders[prop];
     }
 
-    return [responseStream, responseHeaders, version, widgetVersion, mobileWidget, unityWorkflow];
+    return [responseStream, responseHeaders, version, widgetVersion, mobileWidget, unityWorkflow, studyMarquee];
   };
 
   const fetchResource = async path => {
@@ -92,7 +96,7 @@ export async function responseProvider(request) {
   };
 
   const fetchFrictionlessPageAndInlineSnippet = async () => {
-    const [responseStream, responseHeaders, version, widgetVersion, mobileWidget, unityWorkflow] = await fetchFrictionlessPage();
+    const [responseStream, responseHeaders, version, widgetVersion, mobileWidget, unityWorkflow, studyMarquee] = await fetchFrictionlessPage();
 
     if (!verb || !locale || !version || !widgetVersion) {
       throw new Error('Missing metadata');
@@ -113,7 +117,7 @@ export async function responseProvider(request) {
     }
     const dcCoreVersion = widgetVersion.split("_")[0];
 
-    return [responseStream, responseHeaders, dcCoreVersion, mobileWidget, unityWorkflow];
+    return [responseStream, responseHeaders, dcCoreVersion, mobileWidget, unityWorkflow, studyMarquee];
   };
 
   const scriptHashes = [];
@@ -180,12 +184,16 @@ export async function responseProvider(request) {
     });
   };
 
-  const inlineStyles = (dcStyles, miloStyles, verbWidgetStyles, unityWorkflow, prerenderTop) => {
+  const inlineStyles = (dcStyles, miloStyles, verbWidgetStyles, studyMarqueeStyles, unityWorkflow, studyMarquee, prerenderTop) => {
     rewriter.onElement('head', el => {
       el.append(`<style id="inline-milo-styles">${miloStyles}</style>`);
       el.append(`<style id="inline-dc-styles">${dcStyles}</style>`);
       if (unityWorkflow) {
-        el.append(`<style id="inline-verb-widget-styles">${verbWidgetStyles}</style>`);
+        if (studyMarquee) {
+          el.append(`<style id="inline-study-marquee-styles">${studyMarqueeStyles}</style>`);
+        } else {
+          el.append(`<style id="inline-verb-widget-styles">${verbWidgetStyles}</style>`);
+        }
         el.append(`<style>#prerender_verb-widget { position: absolute; top: ${prerenderTop}; left: 0; width: 100%; z-index: -1; pointer-events: auto; }</style></head>`);
       }
     });
@@ -193,23 +201,25 @@ export async function responseProvider(request) {
 
   try {
     const [
-      [responseStream, responseHeaders, dcCoreVersion, mobileWidget, unityWorkflow],
+      [responseStream, responseHeaders, dcCoreVersion, mobileWidget, unityWorkflow, studyMarquee],
       scripts,
       dcConverter,
       dcStyles,
       miloStyles,
-      verbWidgetStyles
+      verbWidgetStyles,
+      studyMarqueeStyles
     ] = await Promise.all([
       fetchFrictionlessPageAndInlineSnippet(),
       fetchResource('/acrobat/scripts/scripts.js'),
       fetchResource('/acrobat/blocks/dc-converter-widget/dc-converter-widget.js'),
       fetchResource('/acrobat/styles/styles.css'),
       fetchResource('/libs/styles/styles.css'),
-      fetchResource('/acrobat/blocks/verb-widget/verb-widget.css')
+      fetchResource('/acrobat/blocks/verb-widget/verb-widget.css'),
+      fetchResource('/acrobat/blocks/study-marquee/study-marquee.css')
     ]);
 
     await inlineScripts(unityWorkflow, mobileWidget, scripts, dcConverter);
-    inlineStyles(dcStyles, miloStyles, verbWidgetStyles, unityWorkflow, prerenderTop);
+    inlineStyles(dcStyles, miloStyles, verbWidgetStyles, studyMarqueeStyles, unityWorkflow, studyMarquee, prerenderTop);
 
     const csp = contentSecurityPolicy(isProd, scriptHashes);
     const acrobat = isProd ? 'https://acrobat.adobe.com' : 'https://stage.acrobat.adobe.com';
@@ -226,13 +236,22 @@ export async function responseProvider(request) {
       headerLink = [...headerLink,
         `</acrobat/blocks/unity/unity.js>;rel="preload";as="script";crossorigin="anonymous"`,
         `</acrobat/blocks/unity/unity.css>;rel="preload";as="style"`,
-        `</acrobat/blocks/verb-widget/verb-widget.js>;rel="preload";as="script";crossorigin="anonymous"`,
-        `</acrobat/blocks/verb-widget/verb-widget.css>;rel="preload";as="style"`,
         `</acrobat/scripts/utils.js>;rel="preload";as="script";crossorigin="anonymous"`,
         `</libs/utils/utils.js>;rel="preload";as="script";crossorigin="anonymous"`,
         `</libs/features/placeholders.js>;rel="preload";as="script";crossorigin="anonymous"`,
         `<${first === 'acrobat' ? '' : `/${first}`}/dc-shared/placeholders.json>;rel="preload";as="fetch";crossorigin="anonymous"`,
       ];
+      if (studyMarquee) {
+        headerLink = [...headerLink,
+          `</acrobat/blocks/study-marquee/study-marquee.js>;rel="preload";as="script";crossorigin="anonymous"`,
+          `</acrobat/blocks/study-marquee/study-marquee.css>;rel="preload";as="style"`,
+        ];
+      } else {
+        headerLink = [...headerLink,
+          `</acrobat/blocks/verb-widget/verb-widget.js>;rel="preload";as="script";crossorigin="anonymous"`,
+          `</acrobat/blocks/verb-widget/verb-widget.css>;rel="preload";as="style"`,
+        ];
+      }
     } else if (!(mobileWidget && request.device.isMobile)) {
       headerLink = [...headerLink,
         `<${acrobat}>;rel="preconnect"`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "async": "^3.2.5",
         "bowser": "^2.11.0",
         "jest-fetch-mock": "^3.0.3",
+        "playwright": "^1.58.2",
         "ws": "^8.18.0",
         "yargs": "^17.7.2"
       },
@@ -51,7 +52,6 @@
         "jest-environment-jsdom": "^29.5.0",
         "koa-proxies": "^0.12.4",
         "microbundle": "^0.15.1",
-        "playwright": "1.56.0",
         "sinon": "13.0.1",
         "stylelint": "14.6.0",
         "stylelint-config-prettier": "9.0.3",
@@ -181,6 +181,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.2.tgz",
       "integrity": "sha512-n7s51eWdaWZ3vGT2tD4T7J6eJs3QoBXydv7vkUM06Bf1cbVD2Kc2UrkzhiQwobfV7NwOnQXYL7UBJ5VPU+RGoQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.13",
@@ -2413,6 +2414,7 @@
       "resolved": "https://registry.npmjs.org/@cucumber/message-streams/-/message-streams-4.0.1.tgz",
       "integrity": "sha512-Kxap9uP5jD8tHUZVjTWgzxemi/0uOsbGjd4LBOSxcJoOCRbESFwemUzilJuzNTB8pcTQUh8D5oudUyxfkJOKmA==",
       "dev": true,
+      "peer": true,
       "peerDependencies": {
         "@cucumber/messages": ">=17.1.1"
       }
@@ -3167,6 +3169,40 @@
         "node": ">=18"
       }
     },
+    "node_modules/@playwright/test/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/playwright": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.0.tgz",
+      "integrity": "sha512-X5Q1b8lOdWIE4KAoHpW3SE8HvUB+ZZsUoN64ZhjnN8dOb1UpujxBtENGiZFE+9F/yhzJwYa+ca3u43FeLbboHA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.56.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
     "node_modules/@puppeteer/browsers": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.3.0.tgz",
@@ -3415,6 +3451,32 @@
         "rollup": "^1.20.0||^2.0.0"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.40.0.tgz",
+      "integrity": "sha512-+Fbls/diZ0RDerhE8kyC6hjADCXA1K4yVNlH0EYfd2XjyH0UGgzaQ8MlT0pCXAThfxv3QUAczHaL+qSv1E4/Cg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.40.0.tgz",
+      "integrity": "sha512-PPA6aEEsTPRz+/4xxAmaoWDqh67N7wFbgFUJGMnanCFs0TV99M0M8QhhaSCks+n6EbQoFvLQgYOGXxlMGQe/6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.40.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.40.0.tgz",
@@ -3427,6 +3489,162 @@
         "darwin"
       ]
     },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.40.0.tgz",
+      "integrity": "sha512-CoLEGJ+2eheqD9KBSxmma6ld01czS52Iw0e2qMZNpPDlf7Z9mj8xmMemxEucinev4LgHalDPczMyxzbq+Q+EtA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.40.0.tgz",
+      "integrity": "sha512-r7yGiS4HN/kibvESzmrOB/PxKMhPTlz+FcGvoUIKYoTyGd5toHp48g1uZy1o1xQvybwwpqpe010JrcGG2s5nkg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.40.0.tgz",
+      "integrity": "sha512-mVDxzlf0oLzV3oZOr0SMJ0lSDd3xC4CmnWJ8Val8isp9jRGl5Dq//LLDSPFrasS7pSm6m5xAcKaw3sHXhBjoRw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.40.0.tgz",
+      "integrity": "sha512-y/qUMOpJxBMy8xCXD++jeu8t7kzjlOCkoxxajL58G62PJGBZVl/Gwpm7JK9+YvlB701rcQTzjUZ1JgUoPTnoQA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.40.0.tgz",
+      "integrity": "sha512-GoCsPibtVdJFPv/BOIvBKO/XmwZLwaNWdyD8TKlXuqp0veo2sHE+A/vpMQ5iSArRUz/uaoj4h5S6Pn0+PdhRjg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.40.0.tgz",
+      "integrity": "sha512-L5ZLphTjjAD9leJzSLI7rr8fNqJMlGDKlazW2tX4IUF9P7R5TMQPElpH82Q7eNIDQnQlAyiNVfRPfP2vM5Avvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.40.0.tgz",
+      "integrity": "sha512-ATZvCRGCDtv1Y4gpDIXsS+wfFeFuLwVxyUBSLawjgXK2tRE6fnsQEkE4csQQYWlBlsFztRzCnBvWVfcae/1qxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.40.0.tgz",
+      "integrity": "sha512-wG9e2XtIhd++QugU5MD9i7OnpaVb08ji3P1y/hNbxrQ3sYEelKJOq1UJ5dXczeo6Hj2rfDEL5GdtkMSVLa/AOg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.40.0.tgz",
+      "integrity": "sha512-vgXfWmj0f3jAUvC7TZSU/m/cOE558ILWDzS7jBhiCAFpY2WEBn5jqgbqvmzlMjtp8KlLcBlXVD2mkTSEQE6Ixw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.40.0.tgz",
+      "integrity": "sha512-uJkYTugqtPZBS3Z136arevt/FsKTF/J9dEMTX/cwR7lsAW4bShzI2R0pJVw+hcBTWF4dxVckYh72Hk3/hWNKvA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.40.0.tgz",
+      "integrity": "sha512-rKmSj6EXQRnhSkE22+WvrqOqRtk733x3p5sWpZilhmjnkHkpeCgWsFFo0dGnUGeA+OZjRl3+VYq+HyCOEuwcxQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.40.0.tgz",
+      "integrity": "sha512-SpnYlAfKPOoVsQqmTFJ0usx0z84bzGOS9anAC0AZ3rdSo3snecihbhFTlJZ8XMwzqAcodjFU4+/SM311dqE5Sw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.40.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.40.0.tgz",
@@ -3437,6 +3655,58 @@
       "optional": true,
       "os": [
         "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.40.0.tgz",
+      "integrity": "sha512-HZvjpiUmSNx5zFgwtQAV1GaGazT2RWvqeDi0hV+AtC8unqqDSsaFjPxfsO6qPtKRRg25SisACWnJ37Yio8ttaw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.40.0.tgz",
+      "integrity": "sha512-UtZQQI5k/b8d7d3i9AZmA/t+Q4tk3hOC0tMOMSq2GlMYOfxbesxG4mJSeDp0EHs30N9bsfwUvs3zF4v/RzOeTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.40.0.tgz",
+      "integrity": "sha512-+m03kvI2f5syIqHXCZLPVYplP8pQch9JHyXKZ3AGMKlg8dCyr2PKHjwRLiW53LTrN/Nc3EqHOKxUxzoSPdKddA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.40.0.tgz",
+      "integrity": "sha512-lpPE1cLfP5oPzVjKMx10pgBmKELQnFJXHgvtHCtuJWOv8MxqdEIMNtgHgBFf7Ea2/7EuVwa9fodWUfXAlXZLZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@sinclair/typebox": {
@@ -3514,7 +3784,6 @@
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
       "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3533,7 +3802,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3542,7 +3810,6 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3555,8 +3822,7 @@
     "node_modules/@testing-library/dom/node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "peer": true
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "node_modules/@testing-library/user-event": {
       "version": "14.5.2",
@@ -3604,8 +3870,7 @@
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "peer": true
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="
     },
     "node_modules/@types/babel__code-frame": {
       "version": "7.0.4",
@@ -4316,6 +4581,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
       "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4463,7 +4729,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -4807,6 +5072,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
       "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "cosmiconfig": "^7.0.0",
@@ -5084,6 +5350,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001541",
         "electron-to-chromium": "^1.4.535",
@@ -6291,7 +6558,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -6317,7 +6583,8 @@
     "node_modules/devtools-protocol": {
       "version": "0.0.1312386",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
-      "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA=="
+      "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
+      "peer": true
     },
     "node_modules/diff": {
       "version": "5.1.0",
@@ -6362,8 +6629,7 @@
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "peer": true
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -6700,6 +6966,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.11.0.tgz",
       "integrity": "sha512-/KRpd9mIRg2raGxHRGwW9ZywYNAClZrHjdueHcrVDuO3a6bj83eoTirCCk0M0yPwOjWYKHwRVRid+xK4F/GHgA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.2.1",
         "@humanwhocodes/config-array": "^0.9.2",
@@ -6926,6 +7193,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz",
       "integrity": "sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.4",
         "array.prototype.flat": "^1.2.5",
@@ -10034,6 +10302,7 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.1.tgz",
       "integrity": "sha512-umfX9d3iuSxTQP4pnzLOz0HKnPg0FaUUIKcye2lOiz3KPu1Y3M3xlz76dISdFPQs37P9eJz1wUpcTS6KDPn9fA==",
+      "peer": true,
       "dependencies": {
         "accepts": "^1.3.5",
         "cache-content-type": "^1.0.0",
@@ -10351,7 +10620,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -11689,11 +11957,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.56.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.0.tgz",
-      "integrity": "sha512-X5Q1b8lOdWIE4KAoHpW3SE8HvUB+ZZsUoN64ZhjnN8dOb1UpujxBtENGiZFE+9F/yhzJwYa+ca3u43FeLbboHA==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.56.0"
+        "playwright-core": "1.58.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -11709,6 +11978,8 @@
       "version": "1.56.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.0.tgz",
       "integrity": "sha512-1SXl7pMfemAMSDn5rkPeZljxOCYAmQnYLBTExuh6E8USHXGSX3dx6lYZN/xPpTz1vimXmPA9CDnILvmJaB8aSQ==",
+      "dev": true,
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -11727,6 +11998,18 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright/node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/polytype": {
@@ -11797,6 +12080,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -13250,6 +13534,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "devOptional": true,
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -14362,6 +14647,7 @@
       "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.6.0.tgz",
       "integrity": "sha512-Xk2sqXYPi9nXgq70nBiZkbQm/QOOKd83NBTaBE1fXEWAEeRlgHnKC/E7kJFlT6K0SaNDOK5yIvR7GFPGsNLuOg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "balanced-match": "^2.0.0",
         "colord": "^2.9.2",
@@ -15082,6 +15368,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15281,7 +15568,6 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
-      "peer": true,
       "bin": {
         "uuid": "dist/esm/bin/uuid"
       }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "jest-environment-jsdom": "^29.5.0",
     "koa-proxies": "^0.12.4",
     "microbundle": "^0.15.1",
-    "playwright": "1.56.0",
     "sinon": "13.0.1",
     "stylelint": "14.6.0",
     "stylelint-config-prettier": "9.0.3",
@@ -85,6 +84,7 @@
     "async": "^3.2.5",
     "bowser": "^2.11.0",
     "jest-fetch-mock": "^3.0.3",
+    "playwright": "^1.58.2",
     "ws": "^8.18.0",
     "yargs": "^17.7.2"
   },

--- a/test/edgeworkers/Acrobat_DC_web_prod/main.jest.js
+++ b/test/edgeworkers/Acrobat_DC_web_prod/main.jest.js
@@ -41,7 +41,9 @@ describe("EdgeWorker that consumes an HTML document and rewrites it", () => {
       } else if (path.includes('/acrobat/styles/styles.css')) {
         response = new HttpResponseStyles();
       } else if (path.includes('/acrobat/blocks/verb-widget/verb-widget.css')) {
-        response = new HttpResponseVerbWidgetStyles();        
+        response = new HttpResponseVerbWidgetStyles();
+      } else if (path.includes('/acrobat/blocks/study-marquee/study-marquee.css')) {
+        response = new HttpResponseVerbWidgetStyles();
       } else {
         response = new HttpResponse404();
       }
@@ -73,6 +75,7 @@ describe("EdgeWorker that consumes an HTML document and rewrites it", () => {
         'https://www.adobe.com/acrobat/styles/styles.css',
         'https://www.adobe.com/libs/styles/styles.css',
         'https://www.adobe.com/acrobat/blocks/verb-widget/verb-widget.css',
+        'https://www.adobe.com/acrobat/blocks/study-marquee/study-marquee.css',
         'https://www.adobe.com/dc/dc-generate-cache/dc-hosted-1.0/pdf-to-ppt-en-us.html'
       ]);
     });
@@ -92,6 +95,7 @@ describe("EdgeWorker that consumes an HTML document and rewrites it", () => {
         'https://www.adobe.com/acrobat/styles/styles.css',
         'https://www.adobe.com/libs/styles/styles.css',
         'https://www.adobe.com/acrobat/blocks/verb-widget/verb-widget.css',
+        'https://www.adobe.com/acrobat/blocks/study-marquee/study-marquee.css',
         'https://www.adobe.com/dc/dc-generate-cache/dc-hosted-1.0/pdf-to-ppt-ja-jp.html'
       ]);
     });
@@ -113,6 +117,7 @@ describe("EdgeWorker that consumes an HTML document and rewrites it", () => {
         'https://www.adobe.com/acrobat/styles/styles.css',
         'https://www.adobe.com/libs/styles/styles.css',
         'https://www.adobe.com/acrobat/blocks/verb-widget/verb-widget.css',
+        'https://www.adobe.com/acrobat/blocks/study-marquee/study-marquee.css',
       ]);
     });
   });

--- a/tools/prerender/prerender.js
+++ b/tools/prerender/prerender.js
@@ -87,9 +87,12 @@ const deviceConfig = {
     });
 
     // Extract basename from URL and create filenames with layout suffix
-    const urlPath = new URL(url).pathname;
+    const { pathname: urlPath, hostname } = new URL(url);
     const pathParts = urlPath.split('/').filter(Boolean);
-    const locale = pathParts[0] === 'acrobat' ? '' : `_${pathParts[0]}`;
+    const isAcrobatSubdomain = ['acrobat.adobe.com', 'stage.acrobat.adobe.com'].includes(hostname);
+    const locale = pathParts[0] === 'acrobat' || (isAcrobatSubdomain && pathParts.length <= 1)
+      ? ''
+      : `_${pathParts[0]}`;
     const basename = path.basename(urlPath, '.html');
     const outputHtmlPath = path.join(__dirname, `${basename}-${layout}.html`);
     const outputJsonPath = path.join(__dirname, `${basename}-${layout}.json`);
@@ -114,6 +117,7 @@ const deviceConfig = {
         section: 'edgekv',
       });
 
+      console.log(`Putting to EdgeKV: /edgekv/v1/networks/${network}/namespaces/${namespace}/groups/${group}${locale}/items/${basename}_${layout}`);
       eg.auth({
         path: `/edgekv/v1/networks/${network}/namespaces/${namespace}/groups/${group}${locale}/items/${basename}_${layout}`,
         method: 'PUT',


### PR DESCRIPTION
## Description

- Adds routing for `acrobat.adobe.com` and `stage.acrobat.adobe.com` subdomains to a dedicated `frictionlessResponseProvider` that serves content from `/dc-shared` paths
- Extends the Acrobat DC edgeworker to detect `.study-marquee` blocks and conditionally inline study-marquee styles/preloads instead of verb-widget styles
- Fixes unit tests and updates dependencies to use local milo libs and duplicate page paths

## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-XXXXXX](https://jira.corp.adobe.com/browse/MWPW-XXXXXX)

## Test URLs
<!-- List the URLs where the changes can be tested -->
- https://main--da-dc--adobecom.aem.live/acrobat/online/compress-pdf
- https://mwpw-XXXXXX--da-dc--adobecom.aem.live/acrobat/online/compress-pdf