### PR TITLE
[MWPW-191521]Remove prerender when actual block loads

### DIFF
--- a/acrobat/blocks/study-marquee/study-marquee.js
+++ b/acrobat/blocks/study-marquee/study-marquee.js
@@ -260,6 +260,40 @@ export default async function init(element) {
     window.location.href = EOLBrowserPage;
     return;
   }
+
+  const prerenderElement = document.querySelector('#prerender_verb-widget');
+  if (prerenderElement && window.PerformanceObserver) {
+    Promise.race([
+      new Promise((resolve) => {
+        try {
+          const lcpObserver = new PerformanceObserver((entries) => {
+            if (entries.getEntries().length > 0) {
+              prerenderElement.remove();
+              lcpObserver.disconnect();
+              resolve();
+            }
+          });
+          lcpObserver.observe({ type: 'largest-contentful-paint', buffered: true });
+        } catch (error) {
+          prerenderElement.remove();
+          resolve();
+        }
+      }),
+      // Fallback timeout - remove after 3 seconds if LCP not detected
+      new Promise((resolve) => {
+        setTimeout(() => {
+          prerenderElement.remove();
+          resolve();
+        }, 3000);
+      }),
+    ]);
+  } else if (prerenderElement) {
+    // Fallback for browsers without PerformanceObserver support
+    setTimeout(() => {
+      prerenderElement.remove();
+    }, 3000);
+  }
+
   window.mph = window.mph || {};
   await loadPlaceholders(['study', 'verb-widget']);
   const VERB = element.classList[1];


### PR DESCRIPTION
## Description
Remove prerender when actual block loads

## Related Issue
Resolves: [MWPW-191521](https://jira.corp.adobe.com/browse/MWPW-191521)

## Test URLs
- https://stage--da-dc--adobecom.aem.live/acrobat/online/quiz-maker
- https://study-marquee-prerender--da-dc--adobecom.aem.live/acrobat/online/quiz-maker
