### PR TITLE
EdgeWorkers Fix Canonical for Subdomain

### DIFF
--- a/edgeworkers/Acrobat_DC_web_prod/main.js
+++ b/edgeworkers/Acrobat_DC_web_prod/main.js
@@ -440,6 +440,16 @@ async function frictionlessResponseProvider(request) {
     });
   };
 
+  // remove wrong canonical caused by duplicating content
+  function fixCanonical() {
+    rewriter.onElement('link[rel="canonical"]', el => {
+      const href = el.getAttribute('href');
+      if (href && href.includes('/dc-shared')) {
+        el.setAttribute('href', href.replace('/dc-shared', ''));
+      }
+    });
+  }
+
   try {
     const miloBaseUrl = '/dc-shared';
     const [
@@ -460,6 +470,7 @@ async function frictionlessResponseProvider(request) {
 
     await inlineScripts(unityWorkflow, mobileWidget, scripts, dcConverter);
     inlineStyles(dcStyles, miloStyles, verbWidgetStyles, unityWorkflow, prerenderTop);
+    fixCanonical();
 
     const csp = contentSecurityPolicy(isProd, scriptHashes);
     const adobeid = isProd ? 'https://adobeid-na1.services.adobe.com' : 'https://adobeid-na1-stg1.services.adobe.com';

--- a/edgeworkers/Acrobat_DC_web_prod/main.js
+++ b/edgeworkers/Acrobat_DC_web_prod/main.js
@@ -445,7 +445,8 @@ async function frictionlessResponseProvider(request) {
     rewriter.onElement('link[rel="canonical"]', el => {
       const href = el.getAttribute('href');
       if (href && href.includes('/dc-shared')) {
-        el.setAttribute('href', href.replace('/dc-shared', ''));
+        const newHref = href.replace('/dc-shared', '');
+        el.replaceWith(`<link rel="canonical" href="${newHref}">`);
       }
     });
   }


### PR DESCRIPTION
## Description
Fix canonical url on acrobat.adobe.com when EdgeWorkers pulls html from /dc-shared path.

https://jira.corp.adobe.com/browse/MWPW-192469

## Test URLs
<!-- List the URLs where the changes can be tested -->
- https://stage--da-dc--adobecom.aem.live/acrobat/online/compress-pdf
- https://edgeworkers-heic-canonical--da-dc--adobecom.aem.live/acrobat/online/compress-pdf
