### PR TITLE
Update scripts to load c2 styles

### DIFF
--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -486,23 +486,29 @@ async function loadPage() {
     }
   })();
 
+  function getCustomMetadata(name, doc = document) {
+    const attr = name && name.includes(':') ? 'property' : 'name';
+    const meta = doc.head.querySelector(`meta[${attr}="${name}"]`);
+    return meta && meta.content;
+  }
+
   // Setup Milo
   const miloLibs = setLibs(LIBS);
-
-  // Import base milo features and run them
-  const { loadArea, setConfig, loadLana, getMetadata, loadIms } = await import(`${miloLibs}/utils/utils.js`);
-  addLocale(ietf);
 
   // Milo and site styles
   if (!document.getElementById('inline-milo-styles')) {
     const paths = [];
-    const stylesPrefix = getMetadata('foundation') === 'c2' ? '/c2' : '';
+    const stylesPrefix = getCustomMetadata('foundation') === 'c2' ? '/c2' : '';
     paths.push(`${miloLibs}${stylesPrefix}/styles/styles.css`);
-    const skin = getMetadata('skin');
+    const skin = getCustomMetadata('skin');
     if (skin) paths.push(`${miloLibs}/styles/skins/${skin}.css`);
     if (STYLES) { paths.push(STYLES); }
     paths.forEach((css) => loadStyle(css));
   }
+
+  // Import base milo features and run them
+  const { loadArea, setConfig, loadLana, getMetadata, loadIms } = await import(`${miloLibs}/utils/utils.js`);
+  addLocale(ietf);
 
   if (getMetadata('commerce')) {
     const { default: replacePlaceholdersWithImages } = await import('./imageReplacer.js');

--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -489,16 +489,20 @@ async function loadPage() {
   // Setup Milo
   const miloLibs = setLibs(LIBS);
 
-  // Milo and site styles
-  if (!document.getElementById('inline-milo-styles')) {
-    const paths = [`${miloLibs}/styles/styles.css`];
-    if (STYLES) { paths.push(STYLES); }
-    paths.forEach((css) => loadStyle(css));
-  }
-
   // Import base milo features and run them
   const { loadArea, setConfig, loadLana, getMetadata, loadIms } = await import(`${miloLibs}/utils/utils.js`);
   addLocale(ietf);
+
+  // Milo and site styles
+  if (!document.getElementById('inline-milo-styles')) {
+    const paths = [];
+    const stylesPrefix = getMetadata('foundation') === 'c2' ? '/c2' : '';
+    paths.push(`${miloLibs}${stylesPrefix}/styles/styles.css`);
+    const skin = getMetadata('skin');
+    if (skin) paths.push(`${miloLibs}/styles/skins/${skin}.css`);
+    if (STYLES) { paths.push(STYLES); }
+    paths.forEach((css) => loadStyle(css));
+  }
 
   if (getMetadata('commerce')) {
     const { default: replacePlaceholdersWithImages } = await import('./imageReplacer.js');


### PR DESCRIPTION
This is the main equivalent to https://github.com/adobecom/upp/pull/17, to allow for C2 styles to be loaded by DA-DC, in order to support the site redesign foundation.

- Before: https://main--da-dc--adobecom.aem.live/acrobat/online/quiz-maker?martech=off
- After: https://load-c2-styles--da-dc--adobecom.aem.live/acrobat/online/quiz-maker?martech=off
