### PR TITLE
[MWPW-186050] Update LANA logs to use Severity levels correctly

### DIFF
--- a/acrobat/blocks/dc-converter-widget/dc-converter-widget.js
+++ b/acrobat/blocks/dc-converter-widget/dc-converter-widget.js
@@ -152,17 +152,23 @@ export default async function init(element) {
   const lanaOptions = {
     sampleRate: 1,
     tags: 'DC_Milo,Frictionless',
+    severity: 'error',
+  };
+  const lanaWarnOptions = {
+    sampleRate: 1,
+    tags: 'DC_Milo,Frictionless',
+    severity: 'warning',
   };
   // LANA
   window.dcwErrors = [];
   if (!DC_WIDGET_VERSION) {
     DC_WIDGET_VERSION = DC_WIDGET_VERSION_FALLBACK;
-    window.lana?.log(`DC WIDGET VERSION IS NOT SET, USING FALLBACK VERSION: ${DC_WIDGET_VERSION_FALLBACK}`, lanaOptions);
+    window.lana?.log(`DC WIDGET VERSION IS NOT SET, USING FALLBACK VERSION: ${DC_WIDGET_VERSION_FALLBACK}`, lanaWarnOptions);
     window.dcwErrors.push(`DC WIDGET VERSION IS NOT SET, USING FALLBACK VERSION: ${DC_WIDGET_VERSION_FALLBACK}`);
   }
   if (!DC_GENERATE_CACHE_VERSION) {
     DC_GENERATE_CACHE_VERSION = DC_GENERATE_CACHE_VERSION_FALLBACK;
-    window.lana?.log(`DC GENERATE CACHE VERSION IS NOT SET, USING FALLBACK VERSION: ${DC_GENERATE_CACHE_VERSION_FALLBACK}`, lanaOptions);
+    window.lana?.log(`DC GENERATE CACHE VERSION IS NOT SET, USING FALLBACK VERSION: ${DC_GENERATE_CACHE_VERSION_FALLBACK}`, lanaWarnOptions);
     window.dcwErrors.push(`DC GENERATE CACHE VERSION IS NOT SET, USING FALLBACK VERSION: ${DC_GENERATE_CACHE_VERSION_FALLBACK}`);
   }
   let WIDGET_ENV = `https://dev.acrobat.adobe.com/dc-hosted/${DC_WIDGET_VERSION}/dc-app-launcher.js`;
@@ -359,7 +365,10 @@ export default async function init(element) {
     }
     const { cause, message, name, type } = err.detail?.wrappedException || {};
     if (err.detail?.wrappedException) {
-      errorString = JSON.stringify(err.detail?.wrappedException, Object.getOwnPropertyNames(err.detail?.wrappedException));
+      errorString = JSON.stringify(
+        err.detail?.wrappedException,
+        Object.getOwnPropertyNames(err.detail?.wrappedException),
+      );
     }
     const errorStringBasic = err.detail?.wrappedException;
 

--- a/acrobat/blocks/rnr/rnr.js
+++ b/acrobat/blocks/rnr/rnr.js
@@ -26,6 +26,7 @@ const RNR_API_KEY = 'dc-general';
 const lanaOptions = {
   sampleRate: 10,
   tags: 'DC_Milo, RnR Block',
+  severity: 'error',
 };
 
 // #endregion
@@ -548,7 +549,7 @@ function initControls(element) {
     };
 
     if (!data.rating) {
-      window.lana.log(`RnR: Invalid rating ${formData.get('rating')}`);
+      window.lana.log(`RnR: Invalid rating ${formData.get('rating')}`, { severity: 'warning' });
       return;
     }
 
@@ -609,7 +610,7 @@ export default async function init(element) {
   initData();
   // Get verb from meta
   if (!metadata.verb) {
-    window.lana.log('RnR: Verb not configured for the rnr widget');
+    window.lana.log('RnR: Verb not configured for the rnr widget', { severity: 'warning' });
   }
   preloadIcons();
   await loadPlaceholders('rnr');

--- a/acrobat/blocks/study-marquee/study-marquee.js
+++ b/acrobat/blocks/study-marquee/study-marquee.js
@@ -10,6 +10,7 @@ const EOLBrowserPage = 'https://acrobat.adobe.com/home/index-browser-eol.html';
 const lanaOptions = {
   sampleRate: 100,
   tags: 'DC_Milo,Project Unity (DC)',
+  severity: 'error',
 };
 
 const ICONS = {
@@ -566,7 +567,7 @@ export default async function init(element) {
       window.dispatchEvent(redirectReady);
       window.lana?.log(
         'Adobe Analytics done callback failed to trigger, 3 second timeout dispatched event.',
-        { sampleRate: 5, tags: 'DC_Milo,Project Unity (DC)' },
+        { sampleRate: 5, tags: 'DC_Milo,Project Unity (DC)', severity: 'warning' },
       );
     }, 3000);
     setCookie('UTS_Uploaded', Date.now(), cookieExp);

--- a/acrobat/blocks/susi-light/susi-light.js
+++ b/acrobat/blocks/susi-light/susi-light.js
@@ -18,8 +18,8 @@ const onRedirect = (e) => {
     // temporary solution: allows analytics to go thru
   }, 100);
 };
-const onError = (e) => {
-  window.lana?.log('on error:', e);
+const onError = () => {
+  window.lana?.log('on error', { severity: 'error' });
 };
 
 export function loadWrapper() {
@@ -34,7 +34,7 @@ function getDestURL(url) {
   try {
     destURL = new URL(url);
   } catch (err) {
-    window.lana?.log(`invalid redirect uri for susi-light: ${url}`);
+    window.lana?.log(`invalid redirect uri for susi-light: ${url}`, { severity: 'error' });
     destURL = new URL('https://www.adobe.com');
   }
   if (isStage) {

--- a/acrobat/blocks/verb-marquee/verb-marquee.js
+++ b/acrobat/blocks/verb-marquee/verb-marquee.js
@@ -59,6 +59,7 @@ const EOLBrowserPage = 'https://acrobat.adobe.com/home/index-browser-eol.html';
 const lanaOptions = {
   sampleRate: 100,
   tags: 'DC_Milo,Project Unity (DC)',
+  severity: 'error',
 };
 
 const ICONS = {
@@ -665,7 +666,7 @@ export default async function init(element) {
       window.dispatchEvent(redirectReady);
       window.lana?.log(
         'Adobe Analytics done callback failed to trigger, 3 second timeout dispatched event.',
-        { sampleRate: 5, tags: 'DC_Milo,Project Unity (DC)' },
+        { sampleRate: 5, tags: 'DC_Milo,Project Unity (DC)', severity: 'warning' },
       );
     }, 3000);
     setCookie('UTS_Uploaded', Date.now(), cookieExp);

--- a/acrobat/blocks/verb-widget/verb-widget.js
+++ b/acrobat/blocks/verb-widget/verb-widget.js
@@ -474,6 +474,7 @@ async function showUpSell(verb, element) {
 const lanaOptions = {
   sampleRate: 1,
   tags: 'DC_Milo,Project Unity (DC)',
+  severity: 'error',
 };
 
 /// icons.js
@@ -916,7 +917,7 @@ export default async function init(element) {
       window.dispatchEvent(redirectReady);
       window.lana?.log(
         'Adobe Analytics done callback failed to trigger, 3 second timeout dispatched event.',
-        { sampleRate: 1, tags: 'DC_Milo,Project Unity (DC)' },
+        { sampleRate: 1, tags: 'DC_Milo,Project Unity (DC)', severity: 'warning' },
       );
     }, 3000);
     setCookie('UTS_Uploaded', Date.now(), cookieExp);

--- a/acrobat/scripts/alloy/verb-widget.js
+++ b/acrobat/scripts/alloy/verb-widget.js
@@ -73,30 +73,36 @@ function eventData(metaData, { appReferrer: referrer, trackingId: tracking }) {
 
 function createPayloadForSplunk(metaData) {
   const {
-    verb, eventName, noOfFiles, uploadTime, type, size, count, workflowStep, uploadType, userAttempts, errorData, chunkUploadAttempt, chunkNumber, assetId, maxRetryCount
+    verb, eventName, noOfFiles, uploadTime, type, size, count, workflowStep,
+    uploadType, userAttempts, errorData, chunkUploadAttempt, chunkNumber, assetId, maxRetryCount,
   } = metaData;
 
   return {
     event: {
       name: eventName,
-      category: "acrobat",
+      category: 'acrobat',
       subcategory: verb,
       ...(uploadTime && { uploadTime }),
-      ...(uploadType && { uploadType })
+      ...(uploadType && { uploadType }),
     },
-    content: { type, size, count, fileType: type, totalSize: size,
+    content: {
+      type,
+      size,
+      count,
+      fileType: type,
+      totalSize: size,
       ...(workflowStep && { workflowStep }),
       ...(noOfFiles && { no_of_files: noOfFiles }),
       ...(chunkUploadAttempt && { chunkUploadAttempt }),
       ...(chunkNumber && { chunkNumber }),
       ...(assetId && { assetId }),
-      ...(maxRetryCount && { maxRetryCount })
+      ...(maxRetryCount && { maxRetryCount }),
     },
     source: {
       user_agent: navigator.userAgent,
       lang: document.documentElement.lang,
-      app_name: `unity`,
-      url: window.location.href
+      app_name: 'unity',
+      url: window.location.href,
     },
     user: {
       locale: document.documentElement.lang.toLocaleLowerCase(),
@@ -113,17 +119,19 @@ function createPayloadForSplunk(metaData) {
   };
 }
 
+// eslint-disable-next-line max-len, compat/compat
 export function sendAnalyticsToSplunk(eventName, verb, metaData, splunkEndpoint, sendBeacon = false) {
   try {
     const eventDataPayload = createPayloadForSplunk({ ...metaData, eventName, verb });
     const payloadString = JSON.stringify(eventDataPayload);
-    if (sendBeacon && navigator.sendBeacon && navigator.sendBeacon(splunkEndpoint, payloadString)) return;
+    if (sendBeacon && navigator.sendBeacon
+      && navigator.sendBeacon(splunkEndpoint, payloadString)) return;
     fetch(splunkEndpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: payloadString,
     });
-  } catch(error) {
+  } catch (error) {
     window.lana?.log(
       `An error occurred while sending ${eventName} to splunk, verb: ${verb}, metadata: ${metaData}, error: ${error}`,
       { sampleRate: 1, tags: 'DC_Milo,Project Unity (DC)', severity: 'error' },

--- a/acrobat/scripts/alloy/verb-widget.js
+++ b/acrobat/scripts/alloy/verb-widget.js
@@ -126,6 +126,7 @@ export function sendAnalyticsToSplunk(eventName, verb, metaData, splunkEndpoint,
     const payloadString = JSON.stringify(eventDataPayload);
     if (sendBeacon && navigator.sendBeacon
       && navigator.sendBeacon(splunkEndpoint, payloadString)) return;
+    // eslint-disable-next-line compat/compat
     fetch(splunkEndpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/acrobat/scripts/alloy/verb-widget.js
+++ b/acrobat/scripts/alloy/verb-widget.js
@@ -126,7 +126,7 @@ export function sendAnalyticsToSplunk(eventName, verb, metaData, splunkEndpoint,
   } catch(error) {
     window.lana?.log(
       `An error occurred while sending ${eventName} to splunk, verb: ${verb}, metadata: ${metaData}, error: ${error}`,
-      { sampleRate: 1, tags: 'DC_Milo,Project Unity (DC)' },
+      { sampleRate: 1, tags: 'DC_Milo,Project Unity (DC)', severity: 'error' },
     );
   }
 }
@@ -148,7 +148,7 @@ export function createEventObject(eventName, verb, metaData, trackingParams, doc
         if (error) {
           window.lana?.log(
             `Error Code: ${error}, Status: 'Unknown', Message: An error occurred while sending ${verbEvent}, Account Type: ${accountType}`,
-            { sampleRate: 1, tags: 'DC_Milo,Project Unity (DC)' },
+            { sampleRate: 1, tags: 'DC_Milo,Project Unity (DC)', severity: 'error' },
           );
         }
       }

--- a/acrobat/scripts/dcLana.js
+++ b/acrobat/scripts/dcLana.js
@@ -1,22 +1,19 @@
 export default function lanaLogging() {
   const fricPage = document.querySelector('meta[name="dc-widget-version"]');
-  const lanaOptions = { sampleRate: 1 };
+  const lanaOptions = { sampleRate: 1, tags: 'DC_Milo,Frictionless', severity: 'error' };
 
-  const lanaCspOptions = { sampleRate: 0.001 };
+  const lanaCspOptions = { sampleRate: 0.001, tags: 'DC_Milo,Frictionless,CSP', severity: 'warning' };
 
   window.dcwErrors?.forEach((error) => {
-    lanaOptions.tags = 'DC_Milo,Frictionless';
     window.lana?.log(error, lanaOptions);
   });
 
   // Content Security Policy Logging
   if (fricPage) {
     window.cspErrors?.forEach((error) => {
-      lanaCspOptions.tags = 'DC_Milo,Frictionless,CSP';
       window.lana?.log(error, lanaCspOptions);
     });
     document.addEventListener('securitypolicyviolation', (e) => {
-      lanaCspOptions.tags = 'DC_Milo,Frictionless,CSP';
       window.lana?.log(`${e.violatedDirective} violation ¶ Refused to load content from ${e.blockedURI}`, lanaCspOptions);
     });
   }

--- a/acrobat/scripts/imageReplacer.js
+++ b/acrobat/scripts/imageReplacer.js
@@ -15,7 +15,7 @@ export default async function replacePlaceholdersWithImages(locale, miloLibs) {
           class: 'credit-cards-icon',
           style: 'min-height: 33px;',
           'data-country': `${country}`,
-          onerror: `window.lana?.log('Failed to load credit-card icon ${country}'); this.remove()`,
+          onerror: `window.lana?.log('Failed to load credit-card icon ${country}', { severity: 'warning' }); this.remove()`,
         });
         p.replaceWith(img);
       }

--- a/acrobat/scripts/utils.js
+++ b/acrobat/scripts/utils.js
@@ -100,7 +100,7 @@ export async function loadPlaceholders(prefix) {
         });
       }
     } catch (error) {
-      window.lana?.log(`Failed to load placeholders: ${error?.message}`);
+      window.lana?.log(`Failed to load placeholders: ${error?.message}`, { severity: 'error' });
     }
   }
 }

--- a/test/blocks/dc-converter-widget/dc-converter-widget-error.test.js
+++ b/test/blocks/dc-converter-widget/dc-converter-widget-error.test.js
@@ -34,7 +34,7 @@ describe('dc-converter-widget block', () => {
     expect(loggedMessage).to.include('type=undefined');
     expect(loggedMessage).to.include('name=TypeError');
     expect(loggedMessage).to.include('message=Cannot read properties of null (reading \'upload\')');
-    expect(loggedMessage).to.include('at http://localhost:2000/acrobat/blocks/dc-converter-widget/dc-converter-widget.js:314:32');
+    expect(loggedMessage).to.include('at http://localhost:2000/acrobat/blocks/dc-converter-widget/dc-converter-widget.js:320:32');
     expect(loggedMessage).to.include('errorStringBasic=TypeError: Cannot read properties of null (reading \'upload\')');
   });
 });


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Update LANA logs to use Severity levels correctly:
- Added `severity: 'error'` to all LANA log calls that report actual errors (API failures, upload errors, validation errors, init failures)
- Added `severity: 'warning'` to LANA log calls for non-critical issues (version fallbacks, analytics timeouts, missing icons, CSP violations)
- Removed redundant inline tags assignments in `dcLana.js` since they're already set in the options object
- Updated test assertion in `dc-converter-widget-error.test.js` to account for shifted line numbers

## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-186050](https://jira.corp.adobe.com/browse/MWPW-186050)

## Test URLs
<!-- List the URLs where the changes can be tested -->
- https://main--da-dc--adobecom.aem.live/acrobat/online/compress-pdf
- https://mwpw-186050--da-dc--adobecom.aem.live/acrobat/online/compress-pdf
