### PR TITLE
[MWPW-192655]Remove DC styles.css aspect-ratio override causing image cropping/rounded corner loss

### DIFF
--- a/acrobat/styles/styles.css
+++ b/acrobat/styles/styles.css
@@ -154,7 +154,6 @@ div [class *= PdfnowLifecycle__dropzone2___] {
 }
 
 .media .image img {
-  aspect-ratio: 5/3;
   width: 100%;
   object-fit: contain;
 }


### PR DESCRIPTION
## Description
Remove DC styles.css aspect-ratio override causing image cropping/rounded corner loss

## Related Issue
Resolves: [MWPW-192655](https://jira.corp.adobe.com/browse/MWPW-192655)

## Test URLs
- https://stage--da-dc--adobecom.aem.live/acrobat/online/compress-pdf
- https://mwpw-192655--da-dc--adobecom.aem.live/acrobat/online/compress-pdf

Testing Notes: 
1. This was initially added in the code to fix a CLS issue. Please test before after to make sure no new CLS is introduced.
2. Also test some other top pages for acrobat that have media block

