### PR TITLE
Added dc-frictionless sha

### DIFF
--- a/acrobat/scripts/contentSecurityPolicy/dev.js
+++ b/acrobat/scripts/contentSecurityPolicy/dev.js
@@ -219,8 +219,8 @@ const scriptSrc = [
   '*.aem.page',
   '*.aem.live',
   'tr.snapchat.com',
-  '\'sha256-dg0pQ3tkJ9KWGwSBExDwP6bSUKm2FRzq/s0tHhkcDtk=\'',
-  '\'sha256-/B9aRx/bHjiUGWHC/33Ku1McTNnFGEiLwTJdRki4www=\'',
+  '\'sha256-dg0pQ3tkJ9KWGwSBExDwP6bSUKm2FRzq/s0tHhkcDtk=\'', // for this repo
+  '\'sha256-/B9aRx/bHjiUGWHC/33Ku1McTNnFGEiLwTJdRki4www=\'', // for acrobat subdomain dc-frictionless
   ';',
 ];
 

--- a/acrobat/scripts/contentSecurityPolicy/dev.js
+++ b/acrobat/scripts/contentSecurityPolicy/dev.js
@@ -220,6 +220,7 @@ const scriptSrc = [
   '*.aem.live',
   'tr.snapchat.com',
   '\'sha256-dg0pQ3tkJ9KWGwSBExDwP6bSUKm2FRzq/s0tHhkcDtk=\'',
+  '\'sha256-/B9aRx/bHjiUGWHC/33Ku1McTNnFGEiLwTJdRki4www=\'',
   ';',
 ];
 

--- a/acrobat/scripts/contentSecurityPolicy/prod.js
+++ b/acrobat/scripts/contentSecurityPolicy/prod.js
@@ -265,6 +265,7 @@ const scriptSrc = [
   'tr.snapchat.com',
   'api.demandbase.com/api/v3',
   '\'sha256-dg0pQ3tkJ9KWGwSBExDwP6bSUKm2FRzq/s0tHhkcDtk=\'',
+  '\'sha256-/B9aRx/bHjiUGWHC/33Ku1McTNnFGEiLwTJdRki4www=\'',
   ';',
 ];
 

--- a/acrobat/scripts/contentSecurityPolicy/prod.js
+++ b/acrobat/scripts/contentSecurityPolicy/prod.js
@@ -264,8 +264,8 @@ const scriptSrc = [
   'rum.hlx.page',
   'tr.snapchat.com',
   'api.demandbase.com/api/v3',
-  '\'sha256-dg0pQ3tkJ9KWGwSBExDwP6bSUKm2FRzq/s0tHhkcDtk=\'',
-  '\'sha256-/B9aRx/bHjiUGWHC/33Ku1McTNnFGEiLwTJdRki4www=\'',
+  '\'sha256-dg0pQ3tkJ9KWGwSBExDwP6bSUKm2FRzq/s0tHhkcDtk=\'', // for this repo
+  '\'sha256-/B9aRx/bHjiUGWHC/33Ku1McTNnFGEiLwTJdRki4www=\'', // for acrobat subdomain dc-frictionless
   ';',
 ];
 

--- a/acrobat/scripts/contentSecurityPolicy/stage.js
+++ b/acrobat/scripts/contentSecurityPolicy/stage.js
@@ -269,8 +269,8 @@ const scriptSrc = [
   's.yimg.jp',
   'yjtag.yahoo.co.jp',
   'tr.snapchat.com',
-  '\'sha256-dg0pQ3tkJ9KWGwSBExDwP6bSUKm2FRzq/s0tHhkcDtk=\'',
-  '\'sha256-/B9aRx/bHjiUGWHC/33Ku1McTNnFGEiLwTJdRki4www=\'',
+  '\'sha256-dg0pQ3tkJ9KWGwSBExDwP6bSUKm2FRzq/s0tHhkcDtk=\'', // for this repo
+  '\'sha256-/B9aRx/bHjiUGWHC/33Ku1McTNnFGEiLwTJdRki4www=\'', // for acrobat subdomain dc-frictionless
   ';',
 ];
 

--- a/acrobat/scripts/contentSecurityPolicy/stage.js
+++ b/acrobat/scripts/contentSecurityPolicy/stage.js
@@ -270,6 +270,7 @@ const scriptSrc = [
   'yjtag.yahoo.co.jp',
   'tr.snapchat.com',
   '\'sha256-dg0pQ3tkJ9KWGwSBExDwP6bSUKm2FRzq/s0tHhkcDtk=\'',
+  '\'sha256-/B9aRx/bHjiUGWHC/33Ku1McTNnFGEiLwTJdRki4www=\'',
   ';',
 ];
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Acrobat subdomain shares the same edgeworkers code living in this repo, so it needs to contain inline sha for both.

## Test URLs
<!-- List the URLs where the changes can be tested -->
- https://stage--da-dc--adobecom.aem.live/acrobat/online/compress-pdf
- https://csp-update--da-dc--adobecom.aem.live/acrobat/online/compress-pdf
