### PR TITLE
[MWPW-193795]fix error message hidden issue when there is a modal in the foreground

### DIFF
--- a/acrobat/blocks/verb-marquee/verb-marquee.css
+++ b/acrobat/blocks/verb-marquee/verb-marquee.css
@@ -624,7 +624,7 @@
   justify-content: center;
   align-items: center;
   padding: 8px;
-  z-index: 2;
+  z-index: 5;
 }
 
 .verb-marquee .close-icon {


### PR DESCRIPTION
## Description
fix error message hidden issue when there is a modal in the foreground

## Related Issue
Resolves: [MWPW-193795](https://jira.corp.adobe.com/browse/MWPW-193795)

## Test URLs
- https://stage--da-dc--adobecom.aem.page/acrobat/online/test/unity/target-test/word-to-pdf
- https://error-z-index--da-dc--adobecom.aem.page/acrobat/online/test/unity/target-test/word-to-pdf
