### PR TITLE
[MWPW-193863]Add solo verb cta logic to verb-marquee for redesign test

### DIFF
--- a/acrobat/blocks/verb-marquee/verb-marquee.css
+++ b/acrobat/blocks/verb-marquee/verb-marquee.css
@@ -280,6 +280,26 @@
   background-color: #0D66D0;
 }
 
+.verb-marquee-cta-solo {
+  display: inline-flex;
+  padding: 9px 18px 10px;
+  min-width: auto;
+  font-size: 17px;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.verb-marquee-cta-solo:hover {
+  text-decoration: none;
+  color: #FFF;
+}
+
+@media screen and (max-width: 600px) {
+  .verb-marquee-cta-solo {
+    inline-size: auto;
+  }
+}
+
 .verb-marquee-mobile-cta {
   display: inline-flex;
   padding: 12px 24px;

--- a/acrobat/blocks/verb-marquee/verb-marquee.js
+++ b/acrobat/blocks/verb-marquee/verb-marquee.js
@@ -502,6 +502,7 @@ export default async function init(element) {
     }
   }
 
+  let soloClicked = false;
   let fileInput = null;
   if (useFileUpload) {
     fileInput = createTag('input', {
@@ -737,6 +738,10 @@ export default async function init(element) {
       }
     });
     fileInput.addEventListener('click', () => {
+      if (soloClicked) {
+        soloClicked = false;
+        return;
+      }
       [
         'filepicker:shown',
         'dropzone:choose-file-clicked',
@@ -780,6 +785,7 @@ export default async function init(element) {
       wrapper.append(labelElement);
       link.remove();
       labelElement.addEventListener('click', (data) => {
+        soloClicked = true;
         [
           'filepicker:shown',
           'cta:choose-file-clicked',

--- a/acrobat/blocks/verb-marquee/verb-marquee.js
+++ b/acrobat/blocks/verb-marquee/verb-marquee.js
@@ -763,6 +763,36 @@ export default async function init(element) {
     errorStateText.textContent = '';
     clearSrAlert();
   });
+  function soloUpload() {
+    if (!useFileUpload || !fileInput || !ctaButton) return;
+    const uploadLinks = document.querySelectorAll('a[href*="#upload"]');
+    uploadLinks.forEach((link) => {
+      const labelElement = createTag('label', {
+        for: 'file-upload',
+        class: 'verb-marquee-cta verb-marquee-cta-solo',
+        tabindex: 0,
+        'daa-ll': ctaButton.textContent,
+        'aria-label': ctaButton.textContent,
+      });
+      labelElement.innerHTML = ctaButton.innerHTML;
+      const wrapper = link.closest('div');
+      if (!wrapper) return;
+      wrapper.append(labelElement);
+      link.remove();
+      labelElement.addEventListener('click', (data) => {
+        [
+          'filepicker:shown',
+          'cta:choose-file-clicked',
+          'files-selected',
+          'entry:clicked',
+          'discover:clicked',
+        ].forEach((analyticsEvent) => {
+          window.analytics.verbAnalytics(analyticsEvent, VERB, { ...data, userAttempts });
+        });
+      });
+    });
+  }
+  runWhenDocumentIsReady(soloUpload);
   element.addEventListener('unity:track-analytics', (e) => {
     const cookieExp = new Date(Date.now() + 30 * 60 * 1000).toUTCString();
     const { event, data } = e.detail || {};


### PR DESCRIPTION
## Description
Add solo verb cta logic to verb-marquee for redesign test

## Related Issue
Resolves: [MWPW-193863](https://jira.corp.adobe.com/browse/MWPW-193863)

## Test URLs
- https://stage--da-dc--adobecom.aem.page/acrobat/online/test/unity/target-test/ai-summary-generator
- https://verb-cta--da-dc--adobecom.aem.page/acrobat/online/test/unity/target-test/ai-summary-generator
