### PR TITLE
[MWPW-194205] Remove unused maxFileSizeFriendly field from LIMITS config

### DIFF
--- a/acrobat/blocks/study-marquee/study-marquee.js
+++ b/acrobat/blocks/study-marquee/study-marquee.js
@@ -23,7 +23,6 @@ const ICONS = {
 export const LIMITS = {
   'quiz-maker': {
     maxFileSize: 104857600, // 100 MB
-    maxFileSizeFriendly: '1 MB',
     acceptedFiles: ['.pdf', '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx', '.rtf', '.txt', '.text', '.vtt'],
     maxNumFiles: 100,
     multipleFiles: true,
@@ -32,7 +31,6 @@ export const LIMITS = {
   },
   'flashcard-maker': {
     maxFileSize: 104857600, // 100 MB
-    maxFileSizeFriendly: '1 MB',
     acceptedFiles: ['.pdf', '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx', '.rtf', '.txt', '.text', '.vtt'],
     maxNumFiles: 100,
     multipleFiles: true,

--- a/acrobat/blocks/verb-marquee/verb-marquee.js
+++ b/acrobat/blocks/verb-marquee/verb-marquee.js
@@ -4,7 +4,6 @@ import { setLibs, isOldBrowser, loadPlaceholders, getEnv as getAppEnv } from '..
 export const LIMITS = {
   fillsign: {
     maxFileSize: 104857600, // 100 MB
-    maxFileSizeFriendly: '100 MB',
     acceptedFiles: ['.pdf'],
     maxNumFiles: 1,
     multipleFiles: false,
@@ -12,19 +11,16 @@ export const LIMITS = {
   },
   'word-to-pdf': {
     maxFileSize: 104857600, // 100 MB
-    maxFileSizeFriendly: '100 MB',
     acceptedFiles: ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.ai', '.form', '.bmp', '.gif', '.indd', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'],
     multipleFiles: true,
   },
   'jpg-to-pdf': {
     maxFileSize: 104857600, // 100 MB
-    maxFileSizeFriendly: '100 MB',
     acceptedFiles: ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.ai', '.form', '.bmp', '.gif', '.indd', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'],
     multipleFiles: true,
   },
   'summarize-pdf': {
     maxFileSize: 104857600, // 100 MB
-    maxFileSizeFriendly: '1 MB',
     acceptedFiles: ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.ai', '.form', '.bmp', '.gif', '.indd', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'],
     maxNumFiles: 1,
     genAI: true,

--- a/acrobat/blocks/verb-widget/verb-widget.js
+++ b/acrobat/blocks/verb-widget/verb-widget.js
@@ -58,7 +58,6 @@ const appEnvCookieMap = {
 export const LIMITS = {
   fillsign: {
     maxFileSize: 104857600, // 100 MB
-    maxFileSizeFriendly: '100 MB', // 100 MB
     acceptedFiles: ['.pdf'],
     maxNumFiles: 1,
     multipleFiles: false,
@@ -74,14 +73,12 @@ export const LIMITS = {
   },
   'ocr-pdf': {
     maxFileSize: 104857600, // 100 MB
-    maxFileSizeFriendly: '1 MB',
     acceptedFiles: ['.pdf'],
     maxNumFiles: 100,
     multipleFiles: true,
   },
   'chat-pdf-student': {
     maxFileSize: 104857600, // 100 MB
-    maxFileSizeFriendly: '1 MB',
     acceptedFiles: ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt'],
     maxNumFiles: 100,
     multipleFiles: true,
@@ -91,7 +88,6 @@ export const LIMITS = {
   },
   'chat-pdf': {
     maxFileSize: 104857600, // 100 MB
-    maxFileSizeFriendly: '1 MB',
     acceptedFiles: ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.ai', '.form', '.bmp', '.gif', '.indd', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'],
     maxNumFiles: 100,
     multipleFiles: true,
@@ -101,7 +97,6 @@ export const LIMITS = {
   },
   'pdf-ai': {
     maxFileSize: 104857600, // 100 MB
-    maxFileSizeFriendly: '1 MB',
     acceptedFiles: ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.ai', '.form', '.bmp', '.gif', '.indd', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'],
     maxNumFiles: 100,
     multipleFiles: true,
@@ -111,7 +106,6 @@ export const LIMITS = {
   },
   'summarize-pdf': {
     maxFileSize: 104857600, // 100 MB
-    maxFileSizeFriendly: '1 MB',
     acceptedFiles: ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.ai', '.form', '.bmp', '.gif', '.indd', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'],
     maxNumFiles: 1,
     subCopy: true,
@@ -119,7 +113,6 @@ export const LIMITS = {
   },
   'split-pdf': {
     maxFileSize: 104857600, // 1 GB
-    maxFileSizeFriendly: '1 GB',
     acceptedFiles: ['.pdf'],
     signedInAcceptedFiles: ['.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.ai', '.form', '.bmp', '.gif', '.indd', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'],
     maxNumFiles: 1,
@@ -127,7 +120,6 @@ export const LIMITS = {
   },
   'combine-pdf': {
     maxFileSize: 104857600, // 100 MB
-    maxFileSizeFriendly: '100 MB', // 100 MB
     acceptedFiles: ['.pdf'],
     maxNumFiles: 100,
     multipleFiles: true,
@@ -135,7 +127,6 @@ export const LIMITS = {
   },
   'rotate-pages': {
     maxFileSize: 104857600, // 100 MB
-    maxFileSizeFriendly: '100 MB', // 100 MB
     acceptedFiles: ['.pdf'],
     maxNumFiles: 100,
     multipleFiles: true,
@@ -143,13 +134,11 @@ export const LIMITS = {
   },
   'protect-pdf': {
     maxFileSize: 104857600, // 100 MB
-    maxFileSizeFriendly: '100 MB', // 100 MB
     acceptedFiles: ['.pdf'],
     maxNumFiles: 1,
   },
   'crop-pages': {
     maxFileSize: 104857600, // 100 MB
-    maxFileSizeFriendly: '1 MB',
     acceptedFiles: ['.pdf'],
     maxNumFiles: 1,
     level: 0,
@@ -157,7 +146,6 @@ export const LIMITS = {
   },
   'add-comment': {
     maxFileSize: 104857600, // 100 MB
-    maxFileSizeFriendly: '1 MB',
     acceptedFiles: ['.pdf'],
     maxNumFiles: 1,
     typeOneLanding: true,
@@ -165,7 +153,6 @@ export const LIMITS = {
   },
   'compress-pdf': {
     maxFileSize: 2147483648,
-    maxFileSizeFriendly: '2 GB',
     acceptedFiles: ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.ai', '.form', '.bmp', '.gif', '.indd', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'],
     multipleFiles: true,
     typeOneLanding: true,
@@ -198,67 +185,56 @@ export const LIMITS = {
   },
   'pdf-to-word': {
     maxFileSize: 262144000, // 250 MB
-    maxFileSizeFriendly: '250 MB',
     acceptedFiles: ['.pdf'],
     multipleFiles: true,
   },
   'pdf-to-excel': {
     maxFileSize: 104857600, // 100 MB
-    maxFileSizeFriendly: '100 MB',
     acceptedFiles: ['.pdf'],
     multipleFiles: true,
   },
   'pdf-to-image': {
     maxFileSize: 104857600, // 100 MB
-    maxFileSizeFriendly: '100 MB',
     acceptedFiles: ['.pdf'],
     multipleFiles: true,
   },
   'pdf-to-png': {
     maxFileSize: 104857600, // 100 MB
-    maxFileSizeFriendly: '100 MB',
     acceptedFiles: ['.pdf'],
     multipleFiles: true,
   },
   'pdf-to-ppt': {
     maxFileSize: 262144000, // 250 MB
-    maxFileSizeFriendly: '250 MB',
     acceptedFiles: ['.pdf'],
     multipleFiles: true,
   },
   createpdf: {
     maxFileSize: 104857600, // 100 MB
-    maxFileSizeFriendly: '100 MB',
     acceptedFiles: ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.ai', '.form', '.bmp', '.gif', '.indd', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'],
     multipleFiles: true,
   },
   'word-to-pdf': {
     maxFileSize: 104857600, // 100 MB
-    maxFileSizeFriendly: '100 MB',
     acceptedFiles: ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.ai', '.form', '.bmp', '.gif', '.indd', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'],
     multipleFiles: true,
   },
   'jpg-to-pdf': {
     maxFileSize: 104857600, // 100 MB
-    maxFileSizeFriendly: '100 MB',
     acceptedFiles: ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.ai', '.form', '.bmp', '.gif', '.indd', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'],
     multipleFiles: true,
   },
   'png-to-pdf': {
     maxFileSize: 104857600, // 100 MB
-    maxFileSizeFriendly: '100 MB',
     acceptedFiles: ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.ai', '.form', '.bmp', '.gif', '.indd', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'],
     multipleFiles: true,
   },
   'excel-to-pdf': {
     maxFileSize: 104857600, // 100 MB
-    maxFileSizeFriendly: '100 MB',
     acceptedFiles: ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.ai', '.form', '.bmp', '.gif', '.indd', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'],
     multipleFiles: true,
   },
   'ppt-to-pdf': {
     maxFileSize: 104857600, // 100 MB
-    maxFileSizeFriendly: '100 MB',
     acceptedFiles: ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.ai', '.form', '.bmp', '.gif', '.indd', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'],
     multipleFiles: true,
   },


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

The maxFileSizeFriendly property was defined across LIMITS configurations in verb-widget.js, verb-marquee.js, and study-marquee.js, but was never read or consumed anywhere in the codebase. This removes dead lines across 3 files with no functional change.

## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-194205](https://jira.corp.adobe.com/browse/MWPW-194205)

## Test URLs
<!-- List the URLs where the changes can be tested -->
- https://main--da-dc--adobecom.aem.live/acrobat/online/compress-pdf
- https://mwpw-194205--da-dc--adobecom.aem.live/acrobat/online/compress-pdf
