### PR TITLE
[MWPW-194527][Code Optimization]Combine all the verbs in limit variable and remove redundant code

### DIFF
--- a/acrobat/blocks/study-marquee/study-marquee.js
+++ b/acrobat/blocks/study-marquee/study-marquee.js
@@ -20,31 +20,13 @@ const ICONS = {
   CLOSE_ICON: '<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg"><g clip-path="url(#clip0_15746_2423)"><g clip-path="url(#clip1_15746_2423)"><path fill-rule="evenodd" clip-rule="evenodd" d="M17.2381 15.9994L19.6944 13.5434C19.8586 13.3793 19.9509 13.1566 19.9509 12.9245C19.951 12.6923 19.8588 12.4696 19.6946 12.3054C19.5305 12.1412 19.3078 12.0489 19.0757 12.0488C18.8435 12.0488 18.6208 12.141 18.4566 12.3051L16.0002 14.7615L13.5435 12.3051C13.3793 12.141 13.1566 12.0489 12.9245 12.049C12.6923 12.0491 12.4697 12.1414 12.3057 12.3056C12.1416 12.4698 12.0495 12.6925 12.0496 12.9246C12.0497 13.1568 12.142 13.3794 12.3062 13.5434L14.7622 15.9994L12.3062 18.4555C12.1427 18.6197 12.051 18.8421 12.0512 19.0738C12.0515 19.3055 12.1436 19.5277 12.3074 19.6916C12.4711 19.8556 12.6933 19.9478 12.925 19.9482C13.1567 19.9486 13.3791 19.8571 13.5435 19.6938L16.0002 17.2374L18.4566 19.6938C18.6208 19.8579 18.8435 19.9501 19.0756 19.9501C19.3078 19.95 19.5305 19.8577 19.6946 19.6935C19.8588 19.5293 19.9509 19.3066 19.9509 19.0745C19.9509 18.8423 19.8586 18.6196 19.6944 18.4555L17.2381 15.9994Z" fill="white"/></g></g><defs><clipPath id="clip0_15746_2423"><rect width="8" height="8" fill="white" transform="translate(12 12)"/></clipPath><clipPath id="clip1_15746_2423"><rect width="8" height="8" fill="white" transform="translate(12 12)"/></clipPath></defs></svg>',
 };
 
+const MB100 = 104857600;
+const STUDY_FILES = ['.pdf', '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx', '.rtf', '.txt', '.text', '.vtt'];
+const STUDY_GENAI = { maxFileSize: MB100, acceptedFiles: STUDY_FILES, maxNumFiles: 100, multipleFiles: true, uploadType: 'multifile-only', genAI: true };
+const group = (verbs, config) => Object.fromEntries(verbs.map((v) => [v, config]));
+
 export const LIMITS = {
-  'quiz-maker': {
-    maxFileSize: 104857600, // 100 MB
-    acceptedFiles: ['.pdf', '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx', '.rtf', '.txt', '.text', '.vtt'],
-    maxNumFiles: 100,
-    multipleFiles: true,
-    uploadType: 'multifile-only',
-    genAI: true,
-  },
-  'flashcard-maker': {
-    maxFileSize: 104857600, // 100 MB
-    acceptedFiles: ['.pdf', '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx', '.rtf', '.txt', '.text', '.vtt'],
-    maxNumFiles: 100,
-    multipleFiles: true,
-    uploadType: 'multifile-only',
-    genAI: true,
-  },
-  'mindmap-maker': {
-    maxFileSize: 104857600, // 100 MB
-    acceptedFiles: ['.pdf', '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx', '.rtf', '.txt', '.text', '.vtt'],
-    maxNumFiles: 100,
-    multipleFiles: true,
-    uploadType: 'multifile-only',
-    genAI: true,
-  },
+  ...group(['quiz-maker', 'flashcard-maker', 'mindmap-maker'], STUDY_GENAI),
 };
 
 function createSvgElement(iconName) {

--- a/acrobat/blocks/study-marquee/study-marquee.js
+++ b/acrobat/blocks/study-marquee/study-marquee.js
@@ -22,12 +22,17 @@ const ICONS = {
 
 const MB100 = 104857600;
 const STUDY_FILES = ['.pdf', '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx', '.rtf', '.txt', '.text', '.vtt'];
-const STUDY_GENAI = { maxFileSize: MB100, acceptedFiles: STUDY_FILES, maxNumFiles: 100, multipleFiles: true, uploadType: 'multifile-only', genAI: true };
-const group = (verbs, config) => Object.fromEntries(verbs.map((v) => [v, config]));
-
-export const LIMITS = {
-  ...group(['quiz-maker', 'flashcard-maker', 'mindmap-maker'], STUDY_GENAI),
+const STUDY_GENAI = {
+  maxFileSize: MB100,
+  acceptedFiles: STUDY_FILES,
+  maxNumFiles: 100,
+  multipleFiles: true,
+  uploadType: 'multifile-only',
+  genAI: true,
 };
+const group = (verbs, config) => verbs.reduce((acc, v) => { acc[v] = config; return acc; }, {});
+
+export const LIMITS = { ...group(['quiz-maker', 'flashcard-maker', 'mindmap-maker'], STUDY_GENAI) };
 
 function createSvgElement(iconName) {
   const svgString = ICONS[iconName];

--- a/acrobat/blocks/verb-marquee/verb-marquee.js
+++ b/acrobat/blocks/verb-marquee/verb-marquee.js
@@ -5,7 +5,7 @@ const PDF_ONLY = ['.pdf'];
 const ALL_FILES = ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.ai', '.form', '.bmp', '.gif', '.indd', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'];
 const SINGLE_PDF = { maxFileSize: MB100, acceptedFiles: PDF_ONLY, maxNumFiles: 1 };
 const MULTI_ALL = { maxFileSize: MB100, acceptedFiles: ALL_FILES, multipleFiles: true };
-const group = (verbs, config) => Object.fromEntries(verbs.map((v) => [v, config]));
+const group = (verbs, config) => verbs.reduce((acc, v) => { acc[v] = config; return acc; }, {});
 
 export const LIMITS = {
   fillsign: { ...SINGLE_PDF, mobileApp: true },

--- a/acrobat/blocks/verb-marquee/verb-marquee.js
+++ b/acrobat/blocks/verb-marquee/verb-marquee.js
@@ -1,30 +1,16 @@
 import { setLibs, isOldBrowser, loadPlaceholders, getEnv as getAppEnv } from '../../scripts/utils.js';
 
-/** Verbs supported by verb-marquee only; values mirror ../verb-widget/verb-widget.js LIMITS. */
+const MB100 = 104857600;
+const PDF_ONLY = ['.pdf'];
+const ALL_FILES = ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.ai', '.form', '.bmp', '.gif', '.indd', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'];
+const SINGLE_PDF = { maxFileSize: MB100, acceptedFiles: PDF_ONLY, maxNumFiles: 1 };
+const MULTI_ALL = { maxFileSize: MB100, acceptedFiles: ALL_FILES, multipleFiles: true };
+const group = (verbs, config) => Object.fromEntries(verbs.map((v) => [v, config]));
+
 export const LIMITS = {
-  fillsign: {
-    maxFileSize: 104857600, // 100 MB
-    acceptedFiles: ['.pdf'],
-    maxNumFiles: 1,
-    multipleFiles: false,
-    mobileApp: true,
-  },
-  'word-to-pdf': {
-    maxFileSize: 104857600, // 100 MB
-    acceptedFiles: ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.ai', '.form', '.bmp', '.gif', '.indd', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'],
-    multipleFiles: true,
-  },
-  'jpg-to-pdf': {
-    maxFileSize: 104857600, // 100 MB
-    acceptedFiles: ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.ai', '.form', '.bmp', '.gif', '.indd', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'],
-    multipleFiles: true,
-  },
-  'summarize-pdf': {
-    maxFileSize: 104857600, // 100 MB
-    acceptedFiles: ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.ai', '.form', '.bmp', '.gif', '.indd', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'],
-    maxNumFiles: 1,
-    genAI: true,
-  },
+  fillsign: { ...SINGLE_PDF, mobileApp: true },
+  'summarize-pdf': { maxFileSize: MB100, acceptedFiles: ALL_FILES, maxNumFiles: 1, genAI: true },
+  ...group(['word-to-pdf', 'jpg-to-pdf'], MULTI_ALL),
 };
 
 const miloLibs = setLibs('/libs');

--- a/acrobat/blocks/verb-widget/verb-widget.js
+++ b/acrobat/blocks/verb-widget/verb-widget.js
@@ -67,17 +67,30 @@ const SINGLE_PDF = { maxFileSize: MB100, acceptedFiles: PDF_ONLY, maxNumFiles: 1
 const MULTI_PDF = { maxFileSize: MB100, acceptedFiles: PDF_ONLY, multipleFiles: true };
 const MULTI_ALL = { maxFileSize: MB100, acceptedFiles: ALL_FILES, multipleFiles: true };
 const GENAI_MULTI = { ...MULTI_ALL, maxNumFiles: 100, uploadType: 'multifile-only', subCopy: true, genAI: true };
-const group = (verbs, config) => Object.fromEntries(verbs.map((v) => [v, config]));
+const group = (verbs, config) => verbs.reduce((acc, v) => { acc[v] = config; return acc; }, {});
 
 export const LIMITS = {
   fillsign: { ...SINGLE_PDF, mobileApp: true, typeOneLanding: true },
   'ocr-pdf': { ...MULTI_PDF, maxNumFiles: 100 },
-  'chat-pdf-student': { maxFileSize: MB100, acceptedFiles: STUDENT_FILES, maxNumFiles: 100, multipleFiles: true, uploadType: 'multifile-only', subCopy: true, genAI: true },
+  'chat-pdf-student': {
+    maxFileSize: MB100,
+    acceptedFiles: STUDENT_FILES,
+    maxNumFiles: 100,
+    multipleFiles: true,
+    uploadType: 'multifile-only',
+    subCopy: true,
+    genAI: true,
+  },
   'summarize-pdf': { maxFileSize: MB100, acceptedFiles: ALL_FILES, maxNumFiles: 1, subCopy: true, genAI: true },
   'split-pdf': { ...SINGLE_PDF, signedInAcceptedFiles: SIGNED_IN_FILES, typeOneLanding: true },
   'add-comment': { ...SINGLE_PDF, typeOneLanding: true },
   'compress-pdf': { maxFileSize: 2147483648, acceptedFiles: ALL_FILES, multipleFiles: true, typeOneLanding: true },
-  sendforsignature: { maxFileSize: 5242880, acceptedFiles: PDF_ONLY, maxNumFiles: 1, mobileApp: true },
+  sendforsignature: {
+    maxFileSize: 5242880,
+    acceptedFiles: PDF_ONLY,
+    maxNumFiles: 1,
+    mobileApp: true,
+  },
   ...group(['number-pages', 'crop-pages'], { ...SINGLE_PDF, level: 0, typeOneLanding: true }),
   ...group(['protect-pdf', 'delete-pages', 'insert-pdf', 'extract-pages', 'reorder-pages'], SINGLE_PDF),
   ...group(['chat-pdf', 'pdf-ai'], GENAI_MULTI),

--- a/acrobat/blocks/verb-widget/verb-widget.js
+++ b/acrobat/blocks/verb-widget/verb-widget.js
@@ -56,189 +56,35 @@ const appEnvCookieMap = {
   prod: 'p_ac_',
 };
 
+const MB100 = 104857600;
+const MB250 = 262144000;
+const PDF_ONLY = ['.pdf'];
+const ALL_FILES = ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.ai', '.form', '.bmp', '.gif', '.indd', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'];
+const STUDENT_FILES = ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt'];
+const SIGNED_IN_FILES = ['.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.ai', '.form', '.bmp', '.gif', '.indd', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'];
+
+const SINGLE_PDF = { maxFileSize: MB100, acceptedFiles: PDF_ONLY, maxNumFiles: 1 };
+const MULTI_PDF = { maxFileSize: MB100, acceptedFiles: PDF_ONLY, multipleFiles: true };
+const MULTI_ALL = { maxFileSize: MB100, acceptedFiles: ALL_FILES, multipleFiles: true };
+const GENAI_MULTI = { ...MULTI_ALL, maxNumFiles: 100, uploadType: 'multifile-only', subCopy: true, genAI: true };
+const group = (verbs, config) => Object.fromEntries(verbs.map((v) => [v, config]));
+
 export const LIMITS = {
-  fillsign: {
-    maxFileSize: 104857600, // 100 MB
-    acceptedFiles: ['.pdf'],
-    maxNumFiles: 1,
-    multipleFiles: false,
-    mobileApp: true,
-    typeOneLanding: true,
-  },
-  'number-pages': {
-    maxFileSize: 104857600, // 100 MB
-    acceptedFiles: ['.pdf'],
-    maxNumFiles: 1,
-    level: 0,
-    typeOneLanding: true,
-  },
-  'ocr-pdf': {
-    maxFileSize: 104857600, // 100 MB
-    acceptedFiles: ['.pdf'],
-    maxNumFiles: 100,
-    multipleFiles: true,
-  },
-  'chat-pdf-student': {
-    maxFileSize: 104857600, // 100 MB
-    acceptedFiles: ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt'],
-    maxNumFiles: 100,
-    multipleFiles: true,
-    uploadType: 'multifile-only',
-    subCopy: true,
-    genAI: true,
-  },
-  'chat-pdf': {
-    maxFileSize: 104857600, // 100 MB
-    acceptedFiles: ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.ai', '.form', '.bmp', '.gif', '.indd', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'],
-    maxNumFiles: 100,
-    multipleFiles: true,
-    uploadType: 'multifile-only',
-    subCopy: true,
-    genAI: true,
-  },
-  'pdf-ai': {
-    maxFileSize: 104857600, // 100 MB
-    acceptedFiles: ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.ai', '.form', '.bmp', '.gif', '.indd', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'],
-    maxNumFiles: 100,
-    multipleFiles: true,
-    uploadType: 'multifile-only',
-    subCopy: true,
-    genAI: true,
-  },
-  'summarize-pdf': {
-    maxFileSize: 104857600, // 100 MB
-    acceptedFiles: ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.ai', '.form', '.bmp', '.gif', '.indd', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'],
-    maxNumFiles: 1,
-    subCopy: true,
-    genAI: true,
-  },
-  'split-pdf': {
-    maxFileSize: 104857600, // 1 GB
-    acceptedFiles: ['.pdf'],
-    signedInAcceptedFiles: ['.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.ai', '.form', '.bmp', '.gif', '.indd', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'],
-    maxNumFiles: 1,
-    typeOneLanding: true,
-  },
-  'combine-pdf': {
-    maxFileSize: 104857600, // 100 MB
-    acceptedFiles: ['.pdf'],
-    maxNumFiles: 100,
-    multipleFiles: true,
-    uploadType: 'multifile-only',
-  },
-  'rotate-pages': {
-    maxFileSize: 104857600, // 100 MB
-    acceptedFiles: ['.pdf'],
-    maxNumFiles: 100,
-    multipleFiles: true,
-    uploadType: 'multifile-only',
-  },
-  'protect-pdf': {
-    maxFileSize: 104857600, // 100 MB
-    acceptedFiles: ['.pdf'],
-    maxNumFiles: 1,
-  },
-  'crop-pages': {
-    maxFileSize: 104857600, // 100 MB
-    acceptedFiles: ['.pdf'],
-    maxNumFiles: 1,
-    level: 0,
-    typeOneLanding: true,
-  },
-  'add-comment': {
-    maxFileSize: 104857600, // 100 MB
-    acceptedFiles: ['.pdf'],
-    maxNumFiles: 1,
-    typeOneLanding: true,
-    // neverRedirect: true,
-  },
-  'compress-pdf': {
-    maxFileSize: 2147483648,
-    acceptedFiles: ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.ai', '.form', '.bmp', '.gif', '.indd', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'],
-    multipleFiles: true,
-    typeOneLanding: true,
-  },
-  'delete-pages': {
-    maxFileSize: 104857600, // 100 MB
-    acceptedFiles: ['.pdf'],
-    maxNumFiles: 1,
-  },
-  'insert-pdf': {
-    maxFileSize: 104857600, // 100 MB
-    acceptedFiles: ['.pdf'],
-    maxNumFiles: 1,
-  },
-  'extract-pages': {
-    maxFileSize: 104857600, // 100 MB
-    acceptedFiles: ['.pdf'],
-    maxNumFiles: 1,
-  },
-  'reorder-pages': {
-    maxFileSize: 104857600, // 100 MB
-    acceptedFiles: ['.pdf'],
-    maxNumFiles: 1,
-  },
-  sendforsignature: {
-    maxFileSize: 5242880, // 5 MB
-    acceptedFiles: ['.pdf'],
-    maxNumFiles: 1,
-    mobileApp: true,
-  },
-  'pdf-to-word': {
-    maxFileSize: 262144000, // 250 MB
-    acceptedFiles: ['.pdf'],
-    multipleFiles: true,
-  },
-  'pdf-to-excel': {
-    maxFileSize: 104857600, // 100 MB
-    acceptedFiles: ['.pdf'],
-    multipleFiles: true,
-  },
-  'pdf-to-image': {
-    maxFileSize: 104857600, // 100 MB
-    acceptedFiles: ['.pdf'],
-    multipleFiles: true,
-  },
-  'pdf-to-png': {
-    maxFileSize: 104857600, // 100 MB
-    acceptedFiles: ['.pdf'],
-    multipleFiles: true,
-  },
-  'pdf-to-ppt': {
-    maxFileSize: 262144000, // 250 MB
-    acceptedFiles: ['.pdf'],
-    multipleFiles: true,
-  },
-  createpdf: {
-    maxFileSize: 104857600, // 100 MB
-    acceptedFiles: ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.ai', '.form', '.bmp', '.gif', '.indd', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'],
-    multipleFiles: true,
-  },
-  'word-to-pdf': {
-    maxFileSize: 104857600, // 100 MB
-    acceptedFiles: ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.ai', '.form', '.bmp', '.gif', '.indd', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'],
-    multipleFiles: true,
-  },
-  'jpg-to-pdf': {
-    maxFileSize: 104857600, // 100 MB
-    acceptedFiles: ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.ai', '.form', '.bmp', '.gif', '.indd', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'],
-    multipleFiles: true,
-  },
-  'png-to-pdf': {
-    maxFileSize: 104857600, // 100 MB
-    acceptedFiles: ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.ai', '.form', '.bmp', '.gif', '.indd', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'],
-    multipleFiles: true,
-  },
-  'excel-to-pdf': {
-    maxFileSize: 104857600, // 100 MB
-    acceptedFiles: ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.ai', '.form', '.bmp', '.gif', '.indd', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'],
-    multipleFiles: true,
-  },
-  'ppt-to-pdf': {
-    maxFileSize: 104857600, // 100 MB
-    acceptedFiles: ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.ai', '.form', '.bmp', '.gif', '.indd', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'],
-    multipleFiles: true,
-  },
+  fillsign: { ...SINGLE_PDF, mobileApp: true, typeOneLanding: true },
+  'ocr-pdf': { ...MULTI_PDF, maxNumFiles: 100 },
+  'chat-pdf-student': { maxFileSize: MB100, acceptedFiles: STUDENT_FILES, maxNumFiles: 100, multipleFiles: true, uploadType: 'multifile-only', subCopy: true, genAI: true },
+  'summarize-pdf': { maxFileSize: MB100, acceptedFiles: ALL_FILES, maxNumFiles: 1, subCopy: true, genAI: true },
+  'split-pdf': { ...SINGLE_PDF, signedInAcceptedFiles: SIGNED_IN_FILES, typeOneLanding: true },
+  'add-comment': { ...SINGLE_PDF, typeOneLanding: true },
+  'compress-pdf': { maxFileSize: 2147483648, acceptedFiles: ALL_FILES, multipleFiles: true, typeOneLanding: true },
+  sendforsignature: { maxFileSize: 5242880, acceptedFiles: PDF_ONLY, maxNumFiles: 1, mobileApp: true },
+  ...group(['number-pages', 'crop-pages'], { ...SINGLE_PDF, level: 0, typeOneLanding: true }),
+  ...group(['protect-pdf', 'delete-pages', 'insert-pdf', 'extract-pages', 'reorder-pages'], SINGLE_PDF),
+  ...group(['chat-pdf', 'pdf-ai'], GENAI_MULTI),
+  ...group(['combine-pdf', 'rotate-pages'], { ...MULTI_PDF, maxNumFiles: 100, uploadType: 'multifile-only' }),
+  ...group(['pdf-to-excel', 'pdf-to-image', 'pdf-to-png'], MULTI_PDF),
+  ...group(['pdf-to-word', 'pdf-to-ppt'], { maxFileSize: MB250, acceptedFiles: PDF_ONLY, multipleFiles: true }),
+  ...group(['createpdf', 'word-to-pdf', 'jpg-to-pdf', 'png-to-pdf', 'excel-to-pdf', 'ppt-to-pdf'], MULTI_ALL),
 };
 
 const DC_ENV = ['www.adobe.com', 'sign.ing', 'edit.ing'].includes(window.location.hostname) ? 'prod' : 'stage';


### PR DESCRIPTION
## Description
[Code Optimization]Combine all the verbs in limit variable and remove redundant code

## Related Issue
Resolves: [MWPW-194527](https://jira.corp.adobe.com/browse/MWPW-194527)

## Test URLs
<!-- List the URLs where the changes can be tested -->
Before - https://stage--da-dc--adobecom.aem.live/acrobat/online/compress-pdf
After - https://MWPW-194527--da-dc--adobecom.aem.live/acrobat/online/compress-pdf

Before - https://stage--da-dc--adobecom.aem.live/acrobat/online/compress-pdf
After - https://MWPW-194527--da-dc--adobecom.aem.live/acrobat/online/quiz-maker

Notes:
## Code Optimization – LIMITS Block Reduction

### LIMITS block
| File | Before | After | Saved | % |
|---|---|---|---|---|
| `verb-widget.js` | 184 lines | 43 lines | **141** | 77% |
| `verb-marquee.js` | 25 lines | 12 lines | **13** | 52% |
| `study-marquee.js` | 26 lines | 10 lines | **16** | 62% |
| **Total** | **235 lines** | **65 lines** | **170 lines** | **72%** |

### Total file reduction
| File | Before | After | Saved |
|---|---|---|---|
| `verb-widget.js` | 1,216 lines | 1,075 lines | **141** |
| `verb-marquee.js` | 953 lines | 939 lines | **14** |
| `study-marquee.js` | 807 lines | 794 lines | **13** |
| **Total** | **2,976 lines** | **2,808 lines** | **168 lines (5.6%)** |

