### PR TITLE
fix(a11y): DOTCOM-180525 - error toast Close button not keyboard accessible

### DIFF
--- a/acrobat/blocks/verb-widget/verb-widget.js
+++ b/acrobat/blocks/verb-widget/verb-widget.js
@@ -726,7 +726,7 @@ export default async function init(element) {
   const errorState = createTag('div', { class: 'error hide' });
   const errorStateText = createTag('p', { class: 'verb-errorText' });
   const errorIcon = createTag('div', { class: 'verb-errorIcon' });
-  const errorCloseBtn = createTag('div', { class: 'verb-errorBtn', role: 'button', tabindex: '0', 'aria-label': 'Close error' });
+  const errorCloseBtn = createTag('button', { class: 'verb-errorBtn', type: 'button', 'aria-label': 'Close error' });
   const srAlert = { announceTimer: null, cleanupTimer: null };
   const clearSrAlert = () => {
     clearTimeout(srAlert.announceTimer);
@@ -930,7 +930,7 @@ export default async function init(element) {
   element.parentNode.style.display = 'block';
 
   widget.addEventListener('click', (e) => {
-    if (e.srcElement.classList.value.includes('error')) { return; }
+    if (e.target.closest('.verb-errorBtn, .error')) { return; }
     if (e.srcElement.classList.value.includes('demo')) { return; }
     if (openFilePicker === true) { button.click(); }
   });


### PR DESCRIPTION
## Summary

Fixes WCAG 2.1.1 Keyboard (Level A) violation on the error toast in all verb-widget pages, including the AI Summary Generator.

Jira: https://jira.corp.adobe.com/browse/DOTCOM-180525

## Changes

**`acrobat/blocks/verb-widget/verb-widget.js`**

**1. `errorCloseBtn` — `div` → native `button`**
```diff
-  const errorCloseBtn = createTag('div', { class: 'verb-errorBtn', role: 'button', tabindex: '0', 'aria-label': 'Close error' });
+  const errorCloseBtn = createTag('button', { class: 'verb-errorBtn', type: 'button', 'aria-label': 'Close error' });
```
Native `<button>` elements are focusable and keyboard-activatable (Enter/Space) without requiring a custom `keydown` handler.

**2. Widget click guard — `e.srcElement` → `e.target.closest()`**
```diff
-    if (e.srcElement.classList.value.includes('error')) { return; }
+    if (e.target.closest('.verb-errorBtn, .error')) { return; }
```
`e.srcElement` is deprecated. The old string check also matched `close-icon error` classes on the SVG inside the close button, swallowing clicks before they reached the close handler.

## Testing
1. Go to https://www.adobe.com/acrobat/online/ai-summary-generator.html
2. Tab to **Select a file**, activate with Enter
3. Select an unsupported file type — toast appears
4. Tab — focus should land on the Close button
5. Press Space or Enter — toast should dismiss
6. Verify clicking the X icon directly also dismisses the toast (regression check for change 2)

_Supersedes PR #110 (branch renamed from `fix/DOTCOM-180525-v2`)_