### PR TITLE
MWPW-194664 Resolve placeholder path against CONFIG.locales in geo-phoneNumber

### DIFF
--- a/acrobat/scripts/geo-phoneNumber.js
+++ b/acrobat/scripts/geo-phoneNumber.js
@@ -1,22 +1,81 @@
 /* eslint-disable compat/compat */
 
-export default async function geoPhoneNumber() {
+function readSessionLocale(key) {
+  const value = sessionStorage.getItem(key);
+  if (!value) return '';
+  try {
+    const parsed = JSON.parse(value);
+    if (parsed && typeof parsed === 'object') {
+      return parsed.country?.toLowerCase() || '';
+    }
+  } catch { /* not JSON */ }
+  return value.toLowerCase();
+}
+
+function getPageLang() {
+  const seg = (window.location?.pathname || '').split('/').filter(Boolean)[0];
+  return seg && /^[a-z]{2}$/i.test(seg) ? seg.toLowerCase() : '';
+}
+
+function getPagePrefix() {
+  const seg = (window.location?.pathname || '').split('/').filter(Boolean)[0];
+  return seg ? seg.toLowerCase() : '';
+}
+
+function placeholderUrl(prefix) {
+  return prefix === '' ? '/dc-shared/placeholders.json' : `/${prefix}/dc-shared/placeholders.json`;
+}
+
+function resolvePrefix(locales, country, lang, pagePrefix) {
+  const norm = country === 'us' ? '' : country;
+  const candidates = [
+    norm,
+    country && lang && country !== lang ? `${country}_${lang}` : null,
+    pagePrefix,
+  ];
+  for (const candidate of candidates) {
+    if (candidate === null || candidate === undefined) continue;
+    if (candidate in locales) return candidate;
+  }
+  return null;
+}
+
+async function fetchPlaceholders(locale, locales) {
+  const lang = getPageLang();
+  const pagePrefix = getPagePrefix();
+
+  if (locales && typeof locales === 'object') {
+    const prefix = resolvePrefix(locales, locale, lang, pagePrefix);
+    if (prefix === null) return { status: 404, json: async () => ({}) };
+    return fetch(placeholderUrl(prefix));
+  }
+
+  const primary = await fetch(placeholderUrl(locale === 'us' ? '' : locale));
+  if (primary.status === 200) return primary;
+
+  if (locale && /^[a-z]{2}$/.test(locale) && locale !== 'us' && lang && lang !== locale) {
+    const langFallback = await fetch(placeholderUrl(`${locale}_${lang}`));
+    if (langFallback.status === 200) return langFallback;
+  }
+
+  if (pagePrefix && pagePrefix !== locale) {
+    const prefixFallback = await fetch(placeholderUrl(pagePrefix));
+    if (prefixFallback.status === 200) return prefixFallback;
+  }
+
+  return primary;
+}
+
+export default async function geoPhoneNumber(locales) {
   const geoTwo = await fetch('https://geo2.adobe.com/json/');
   const urlParams = new URLSearchParams(window.location.search);
   const geoData = await geoTwo.json();
 
-  let newLocale = JSON.parse(sessionStorage.getItem('international'))?.country?.toLowerCase()
+  const newLocale = readSessionLocale('international')
   || urlParams.get('akamaiLocale')?.toLowerCase()
   || geoData?.country?.toLowerCase()
-  || JSON.parse(sessionStorage.getItem('international'))?.country?.toLowerCase()
-  || JSON.parse(sessionStorage.getItem('feds_location'))?.country?.toLowerCase()
+  || readSessionLocale('feds_location')
   || '';
-
-  if (newLocale === 'us' || newLocale === '/' || newLocale === '//') {
-    newLocale = '/';
-  } else {
-    newLocale = `/${newLocale}/`;
-  }
   const updatePhoneNumber = (visNum, i) => {
     const phoneNumberEle = document.querySelector(`.${i}`);
     phoneNumberEle.href = `tel:${visNum}`;
@@ -32,7 +91,7 @@ export default async function geoPhoneNumber() {
     }
   };
 
-  const placeHolderJson = await fetch(`${newLocale}dc-shared/placeholders.json`);
+  const placeHolderJson = await fetchPlaceholders(newLocale, locales);
   if (placeHolderJson.status !== 200) return;
   const placeHolderJsonData = await placeHolderJson.json();
   placeHolderJsonData.data = placeHolderJsonData.data.map((val) => ({

--- a/acrobat/scripts/geo-phoneNumber.js
+++ b/acrobat/scripts/geo-phoneNumber.js
@@ -34,8 +34,7 @@ function resolvePrefix(locales, country, lang, pagePrefix) {
     pagePrefix,
   ];
   for (const candidate of candidates) {
-    if (candidate === null || candidate === undefined) continue;
-    if (candidate in locales) return candidate;
+    if (candidate != null && candidate in locales) return candidate;
   }
   return null;
 }

--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -552,7 +552,7 @@ async function loadPage() {
 
   if (document.querySelectorAll('a[class*="geo-pn"]').length > 0 || document.querySelectorAll('a[href*="geo"]').length > 0) {
     const { default: geoPhoneNumber } = await import('./geo-phoneNumber.js');
-    geoPhoneNumber();
+    geoPhoneNumber(CONFIG.locales);
   }
 
   // Import tooltip accessibility implementation for WCAG 1.4.13 and 4.1.2

--- a/test/scripts/geo-phoneNumber.jest.js
+++ b/test/scripts/geo-phoneNumber.jest.js
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+/* eslint-env jest */
 import geoPhoneNumber from '../../acrobat/scripts/geo-phoneNumber';
 
 // Mocking fetch API
@@ -65,4 +66,333 @@ describe('geoPhoneNumber', () => {
     expect(phoneLink.textContent).toEqual('800 915 9430');
     expect(phoneLink.href).toEqual('tel:800 915 9430');
   })
+});
+
+function makeFetchMock(routes = [], geoCountry = 'US') {
+  return jest.fn(async (url) => {
+    if (url === 'https://geo2.adobe.com/json/') {
+      return { status: 200, json: async () => ({ country: geoCountry }) };
+    }
+    const route = routes.find((r) => (typeof r.match === 'function' ? r.match(url) : r.match === url));
+    if (route) {
+      return { status: route.status, json: async () => route.data || { data: [] } };
+    }
+    return { status: 404, json: async () => ({}) };
+  });
+}
+
+describe('geoPhoneNumber - patch behavior', () => {
+  let originalFetch;
+  let originalLocation;
+
+  beforeAll(() => {
+    originalFetch = window.fetch;
+    originalLocation = window.location;
+  });
+
+  afterAll(() => {
+    window.fetch = originalFetch;
+    delete window.location;
+    window.location = originalLocation;
+  });
+
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    document.body.innerHTML = '<a class="geo-pn3 geo-pn" number-type="phone-business" href="tel:%7B%7Bphone-business-geo%7D%7D">{{phone-business}}</a>';
+  });
+
+  function setLocation(pathname, search = '') {
+    delete window.location;
+    window.location = { pathname, search };
+  }
+
+  function placeholderFetchUrls() {
+    return window.fetch.mock.calls
+      .map((c) => c[0])
+      .filter((u) => u !== 'https://geo2.adobe.com/json/');
+  }
+
+  it('reads sessionStorage.international as a plain string without throwing (current Milo shape)', async () => {
+    window.sessionStorage.setItem('international', 'be_fr');
+    setLocation('/fr/');
+    window.fetch = makeFetchMock([
+      {
+        match: '/be_fr/dc-shared/placeholders.json',
+        status: 200,
+        data: { data: [{ key: 'phone-business', value: '+32 1 234 5678' }] },
+      },
+    ]);
+
+    await expect(geoPhoneNumber()).resolves.not.toThrow();
+    expect(placeholderFetchUrls()).toContain('/be_fr/dc-shared/placeholders.json');
+    expect(document.querySelector('.geo-pn3').textContent).toBe('+32 1 234 5678');
+  });
+
+  it('still understands the legacy JSON shape (backward-compatible)', async () => {
+    window.sessionStorage.setItem('international', JSON.stringify({ country: 'BE' }));
+    setLocation('/fr/');
+    window.fetch = makeFetchMock([
+      { match: '/be/dc-shared/placeholders.json', status: 404 },
+      {
+        match: '/be_fr/dc-shared/placeholders.json',
+        status: 200,
+        data: { data: [{ key: 'phone-business', value: '+32 1 234 5678' }] },
+      },
+    ]);
+
+    await geoPhoneNumber();
+    expect(placeholderFetchUrls()).toEqual(expect.arrayContaining([
+      '/be/dc-shared/placeholders.json',
+      '/be_fr/dc-shared/placeholders.json',
+    ]));
+  });
+
+  it('does not throw when sessionStorage.international is unparseable garbage', async () => {
+    window.sessionStorage.setItem('international', 'asdf%%notvalid');
+    setLocation('/fr/');
+    window.fetch = makeFetchMock([]);
+
+    await expect(geoPhoneNumber()).resolves.not.toThrow();
+  });
+
+  it('falls back from /be/ to /be_fr/ when the primary 404s and the page lang is fr', async () => {
+    setLocation('/fr/foo/bar', '?akamaiLocale=be');
+    window.fetch = makeFetchMock([
+      { match: '/be/dc-shared/placeholders.json', status: 404 },
+      {
+        match: '/be_fr/dc-shared/placeholders.json',
+        status: 200,
+        data: { data: [{ key: 'phone-business', value: '+32 1 234 5678' }] },
+      },
+    ]);
+
+    await geoPhoneNumber();
+    expect(placeholderFetchUrls()).toEqual([
+      '/be/dc-shared/placeholders.json',
+      '/be_fr/dc-shared/placeholders.json',
+    ]);
+  });
+
+  it('falls back to the page URL prefix when both country and country+lang 404 (gb on /uk/)', async () => {
+    setLocation('/uk/foo', '?akamaiLocale=gb');
+    window.fetch = makeFetchMock([
+      { match: '/gb/dc-shared/placeholders.json', status: 404 },
+      { match: '/gb_uk/dc-shared/placeholders.json', status: 404 },
+      {
+        match: '/uk/dc-shared/placeholders.json',
+        status: 200,
+        data: { data: [{ key: 'phone-business', value: '+44 800 000 0000' }] },
+      },
+    ]);
+
+    await geoPhoneNumber();
+    expect(placeholderFetchUrls()).toEqual([
+      '/gb/dc-shared/placeholders.json',
+      '/gb_uk/dc-shared/placeholders.json',
+      '/uk/dc-shared/placeholders.json',
+    ]);
+  });
+
+  it('falls back to /africa/ for a sub-Saharan country on a regional page', async () => {
+    setLocation('/africa/foo', '?akamaiLocale=ke');
+    window.fetch = makeFetchMock([
+      { match: '/ke/dc-shared/placeholders.json', status: 404 },
+      {
+        match: '/africa/dc-shared/placeholders.json',
+        status: 200,
+        data: { data: [{ key: 'phone-business', value: '+27 11 555 0100' }] },
+      },
+    ]);
+
+    await geoPhoneNumber();
+    expect(placeholderFetchUrls()).toEqual([
+      '/ke/dc-shared/placeholders.json',
+      '/africa/dc-shared/placeholders.json',
+    ]);
+  });
+
+  it('honors language encoded in the URL prefix (Arabic MENA via /mena_ar/)', async () => {
+    setLocation('/mena_ar/foo', '?akamaiLocale=eg');
+    window.fetch = makeFetchMock([
+      { match: '/eg/dc-shared/placeholders.json', status: 404 },
+      {
+        match: '/mena_ar/dc-shared/placeholders.json',
+        status: 200,
+        data: { data: [{ key: 'phone-business', value: '+20 2 1234 5678' }] },
+      },
+    ]);
+
+    await geoPhoneNumber();
+    expect(placeholderFetchUrls()).toEqual([
+      '/eg/dc-shared/placeholders.json',
+      '/mena_ar/dc-shared/placeholders.json',
+    ]);
+  });
+
+  it('does not issue a fallback fetch for single-prefix locales like /de/ (regression guard)', async () => {
+    setLocation('/de/', '?akamaiLocale=de');
+    window.fetch = makeFetchMock([
+      {
+        match: '/de/dc-shared/placeholders.json',
+        status: 200,
+        data: { data: [{ key: 'phone-business', value: '+49 800 000 0000' }] },
+      },
+    ]);
+
+    await geoPhoneNumber();
+    expect(placeholderFetchUrls()).toEqual(['/de/dc-shared/placeholders.json']);
+  });
+});
+
+describe('geoPhoneNumber - validates path against CONFIG.locales', () => {
+  const dcLocales = {
+    '': { ietf: 'en-US' },
+    de: { ietf: 'de-DE' },
+    fr: { ietf: 'fr-FR' },
+    uk: { ietf: 'en-GB' },
+    africa: { ietf: 'en' },
+    mena_ar: { ietf: 'ar' },
+    be_fr: { ietf: 'fr-BE' },
+    be_en: { ietf: 'en-BE' },
+    be_nl: { ietf: 'nl-BE' },
+    eg_ar: { ietf: 'ar-EG' },
+    eg_en: { ietf: 'en-EG' },
+  };
+
+  let originalFetch;
+  let originalLocation;
+
+  beforeAll(() => {
+    originalFetch = window.fetch;
+    originalLocation = window.location;
+  });
+
+  afterAll(() => {
+    window.fetch = originalFetch;
+    delete window.location;
+    window.location = originalLocation;
+  });
+
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    document.body.innerHTML = '<a class="geo-pn3 geo-pn" number-type="phone-business" href="tel:%7B%7Bphone-business-geo%7D%7D">{{phone-business}}</a>';
+  });
+
+  function setLocation(pathname, search = '') {
+    delete window.location;
+    window.location = { pathname, search };
+  }
+
+  function placeholderFetchUrls() {
+    return window.fetch.mock.calls
+      .map((c) => c[0])
+      .filter((u) => u !== 'https://geo2.adobe.com/json/');
+  }
+
+  it('visitor in DE on US root page → single fetch to /de/, no 404 pings', async () => {
+    setLocation('/', '');
+    window.fetch = makeFetchMock([
+      {
+        match: '/de/dc-shared/placeholders.json',
+        status: 200,
+        data: { data: [{ key: 'phone-business', value: '+49 800 000 0000' }] },
+      },
+    ], 'DE');
+
+    await geoPhoneNumber(dcLocales);
+    expect(placeholderFetchUrls()).toEqual(['/de/dc-shared/placeholders.json']);
+    expect(document.querySelector('.geo-pn3').textContent).toBe('+49 800 000 0000');
+  });
+
+  it('visitor in US (country=us) → resolves to root, single fetch to /dc-shared/placeholders.json', async () => {
+    setLocation('/', '');
+    window.fetch = makeFetchMock([
+      {
+        match: '/dc-shared/placeholders.json',
+        status: 200,
+        data: { data: [{ key: 'phone-business', value: '800 915 9430' }] },
+      },
+    ], 'US');
+
+    await geoPhoneNumber(dcLocales);
+    expect(placeholderFetchUrls()).toEqual(['/dc-shared/placeholders.json']);
+  });
+
+  it('country=gb on /uk/ → resolves to uk via tier 3, never pings /gb/ or /gb_xx/', async () => {
+    setLocation('/uk/foo', '?akamaiLocale=gb');
+    window.fetch = makeFetchMock([
+      {
+        match: '/uk/dc-shared/placeholders.json',
+        status: 200,
+        data: { data: [{ key: 'phone-business', value: '+44 800 000 0000' }] },
+      },
+    ]);
+
+    await geoPhoneNumber(dcLocales);
+    expect(placeholderFetchUrls()).toEqual(['/uk/dc-shared/placeholders.json']);
+  });
+
+  it('country=be on /fr/ → resolves to be_fr via tier 2, never pings /be/', async () => {
+    setLocation('/fr/foo', '?akamaiLocale=be');
+    window.fetch = makeFetchMock([
+      {
+        match: '/be_fr/dc-shared/placeholders.json',
+        status: 200,
+        data: { data: [{ key: 'phone-business', value: '+32 1 234 5678' }] },
+      },
+    ]);
+
+    await geoPhoneNumber(dcLocales);
+    expect(placeholderFetchUrls()).toEqual(['/be_fr/dc-shared/placeholders.json']);
+  });
+
+  it('country=ke on /africa/ → resolves to africa via tier 3, never pings /ke/', async () => {
+    setLocation('/africa/foo', '?akamaiLocale=ke');
+    window.fetch = makeFetchMock([
+      {
+        match: '/africa/dc-shared/placeholders.json',
+        status: 200,
+        data: { data: [{ key: 'phone-business', value: '+27 11 555 0100' }] },
+      },
+    ]);
+
+    await geoPhoneNumber(dcLocales);
+    expect(placeholderFetchUrls()).toEqual(['/africa/dc-shared/placeholders.json']);
+  });
+
+  it('country=eg on /mena_ar/ → resolves to mena_ar via tier 3, never pings /eg/', async () => {
+    setLocation('/mena_ar/foo', '?akamaiLocale=eg');
+    window.fetch = makeFetchMock([
+      {
+        match: '/mena_ar/dc-shared/placeholders.json',
+        status: 200,
+        data: { data: [{ key: 'phone-business', value: '+20 2 1234 5678' }] },
+      },
+    ]);
+
+    await geoPhoneNumber(dcLocales);
+    expect(placeholderFetchUrls()).toEqual(['/mena_ar/dc-shared/placeholders.json']);
+  });
+
+  it('country=de on /de/ (single-prefix locale) → exactly one fetch, no fallbacks', async () => {
+    setLocation('/de/', '?akamaiLocale=de');
+    window.fetch = makeFetchMock([
+      {
+        match: '/de/dc-shared/placeholders.json',
+        status: 200,
+        data: { data: [{ key: 'phone-business', value: '+49 800 000 0000' }] },
+      },
+    ]);
+
+    await geoPhoneNumber(dcLocales);
+    expect(placeholderFetchUrls()).toEqual(['/de/dc-shared/placeholders.json']);
+  });
+
+  it('no candidate is in the locales map → no placeholder fetch issued at all', async () => {
+    setLocation('/foo/bar', '?akamaiLocale=zz');
+    window.fetch = makeFetchMock([], 'ZZ');
+
+    await expect(geoPhoneNumber(dcLocales)).resolves.not.toThrow();
+    expect(placeholderFetchUrls()).toEqual([]);
+  });
 });

--- a/test/scripts/geo-phoneNumber.jest.js
+++ b/test/scripts/geo-phoneNumber.jest.js
@@ -2,7 +2,8 @@
  * @jest-environment jsdom
  */
 /* eslint-env jest */
-import geoPhoneNumber from '../../acrobat/scripts/geo-phoneNumber';
+/* eslint-disable compat/compat */
+import geoPhoneNumber from '../../acrobat/scripts/geo-phoneNumber.js';
 
 // Mocking fetch API
 window.fetch = jest.fn((url) => {
@@ -10,7 +11,7 @@ window.fetch = jest.fn((url) => {
     status: 200,
     json: () => {
       if (url.includes('dc-shared/placeholders.json')) {
-        return Promise.resolve({ data: [{ key: 'phone-business', value: '800\u00A0915\u00A09430' }]});
+        return Promise.resolve({ data: [{ key: 'phone-business', value: '800\u00A0915\u00A09430' }] });
       }
       return Promise.resolve({ country: 'us' });
     },
@@ -19,9 +20,7 @@ window.fetch = jest.fn((url) => {
 });
 
 // Mocking sessionStorage
-global.sessionStorage = {
-  getItem: jest.fn(() => JSON.stringify({ country: 'us' })),
-};
+global.sessionStorage = { getItem: jest.fn(() => JSON.stringify({ country: 'us' })) };
 
 // Mocking window.location
 delete window.location;
@@ -65,7 +64,7 @@ describe('geoPhoneNumber', () => {
     const phoneLink = document.querySelector('.geo-pn3 a');
     expect(phoneLink.textContent).toEqual('800 915 9430');
     expect(phoneLink.href).toEqual('tel:800 915 9430');
-  })
+  });
 });
 
 function makeFetchMock(routes = [], geoCountry = 'US') {


### PR DESCRIPTION
## Description
Localized phone numbers now render reliably for visitors whose geo-resolved country code (`be`, `ch`, `lu`, …) doesn't have a one-to-one DC content prefix (`be_fr`, `ch_fr`, `lu_fr`, …), and on pages where Milo writes `sessionStorage.international` as a plain string instead of legacy JSON.

**What changed**
- `geoPhoneNumber(locales)` validates the candidate prefix against the in-memory `CONFIG.locales` map before fetching, so the happy path is exactly one request to a known-good URL.
- Candidate order: `country` → `country_lang` → page URL prefix. First match wins.
- `readSessionLocale()` supports both plain-string and legacy JSON shapes for `sessionStorage.international`.
- `scripts.js` passes `CONFIG.locales` into `geoPhoneNumber()`.
- When locales isn't passed, the original cascade of live fetches is preserved (existing test/caller behavior unchanged).
- Backwards-compatible: the `locales` parameter is optional. Existing callers and the original unit tests behave exactly as before.
- 16 new Jest cases covering the validated path, `sessionStorage` parsing, and the cascade fallback.

**Open questions**
- Market-selector country change: the resolver does not consult the `country` cookie or `?country=` URL param set by `setMarket()`, so a visitor who picks "France" via market-selector but stays physically in Belgium will still resolve to `be_fr` (geo wins). Same as pre-patch behavior -- flagging in case the ticket owner wants this expanded in scope or filed as a follow-up.
- Country→region rollup: visitors in countries with no DC content prefix (e.g., `ke`, `tn`, `ma` outside `/africa/...`) still bail silently. DC's `CONFIG.mepLingoCountryToRegion` (`scripts.js` lines 356-360) already maps these countries to their content regions; it just isn't consulted yet by `geo-phoneNumber.js`. Open question for reviewers: when none of the existing candidates match, should resolvePrefix also try the rolled-up region from that map — applied always, or only when langfirst is on? Or follow-up ticket?

**Steps to QA** 
Open the Before and After test URL below and scroll to the telephone number at the bottom of the page: 
Actual (Before): `0805 770077`
Expected (After): `0800 80982`

Resolves: [MWPW-194664](https://jira.corp.adobe.com/browse/MWPW-194664)
further described here: [DOTCOM-184523](https://jira.corp.adobe.com/browse/DOTCOM-184523)

## Test URLs
- Before: https://main--da-dc--adobecom.aem.page/fr/acrobat/pricing?akamaiLocale=be&country=be
- After: https://geophonenumbers-patch--da-dc--adobecom.aem.page/fr/acrobat/pricing?akamaiLocale=be&country=be
