### PR TITLE
[MWPW-199357] [iOS]Fix: Accept all file types when type is ai/indd/psd

### DIFF
--- a/acrobat/blocks/verb-widget/verb-widget.js
+++ b/acrobat/blocks/verb-widget/verb-widget.js
@@ -512,6 +512,13 @@ export default async function init(element) {
 
   const isMobile = isMobileDevice();
   const isTablet = isTabletDevice();
+  const isIOS = /iphone|ipad|ipod/i.test(navigator.userAgent);
+  const IOS_UNKNOWN_EXTS = new Set(['.ai', '.psd', '.indd', '.form']);
+  const getAcceptValue = (verb) => {
+    const accepted = LIMITS[verb]?.acceptedFiles;
+    if (isIOS && accepted?.some((ext) => IOS_UNKNOWN_EXTS.has(ext))) return '*/*';
+    return accepted;
+  };
 
   const { locale } = getConfig();
   const ppURL = window.mph['verb-widget-privacy-policy-url'] || `https://www.adobe.com${locale.prefix}/privacy/policy.html`;
@@ -573,7 +580,7 @@ export default async function init(element) {
 
   const button = createTag('input', {
     type: 'file',
-    accept: LIMITS[VERB]?.acceptedFiles,
+    accept: getAcceptValue(VERB),
     id: 'file-upload',
     class: 'hide',
     'aria-hidden': true,


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Accept all file types when type is ai/indd/psd

On iOS, the native file picker does not recognize .ai, .psd, .indd, or .form file extensions — setting those as the accept attribute effectively blocks users from selecting any file.
Added iOS detection and a getAcceptValue helper in verb-widget.js that falls back to `*/*` when the verb accepts any of those unknown extensions and the user is on an iOS device.

## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-199357](https://jira.corp.adobe.com/browse/MWPW-199357)

## Test URLs
https://mwpw-199357--da-dc--adobecom.aem.page/acrobat/online/test/indd-to-pdf?unitylibs=stage
