### PR TITLE
[MWPW-199357] Add tests for iOS file picker accept attribute fix

### DIFF
--- a/test/blocks/verb-widget/mocks/body-ai-to-pdf.html
+++ b/test/blocks/verb-widget/mocks/body-ai-to-pdf.html
@@ -1,0 +1,15 @@
+<main>
+  <div>
+    <div class="verb-widget ai-to-pdf">
+      <div>
+        <div>
+          <h1 id="ai-to-pdf-converter">AI to PDF Converter</h1>
+        </div>
+      </div>
+      <div>
+        <div>{{verb-widget-legal}}</div>
+      </div>
+    </div>
+    <div class="unity workflow-acrobat"></div>
+  </div>
+</main>

--- a/test/blocks/verb-widget/mocks/body-bmp-to-pdf.html
+++ b/test/blocks/verb-widget/mocks/body-bmp-to-pdf.html
@@ -1,0 +1,15 @@
+<main>
+  <div>
+    <div class="verb-widget bmp-to-pdf">
+      <div>
+        <div>
+          <h1 id="bmp-to-pdf-converter">BMP to PDF Converter</h1>
+        </div>
+      </div>
+      <div>
+        <div>{{verb-widget-legal}}</div>
+      </div>
+    </div>
+    <div class="unity workflow-acrobat"></div>
+  </div>
+</main>

--- a/test/blocks/verb-widget/mocks/body-gif-to-pdf.html
+++ b/test/blocks/verb-widget/mocks/body-gif-to-pdf.html
@@ -1,0 +1,15 @@
+<main>
+  <div>
+    <div class="verb-widget gif-to-pdf">
+      <div>
+        <div>
+          <h1 id="gif-to-pdf-converter">GIF to PDF Converter</h1>
+        </div>
+      </div>
+      <div>
+        <div>{{verb-widget-legal}}</div>
+      </div>
+    </div>
+    <div class="unity workflow-acrobat"></div>
+  </div>
+</main>

--- a/test/blocks/verb-widget/mocks/body-image-to-pdf.html
+++ b/test/blocks/verb-widget/mocks/body-image-to-pdf.html
@@ -1,0 +1,15 @@
+<main>
+  <div>
+    <div class="verb-widget image-to-pdf">
+      <div>
+        <div>
+          <h1 id="image-to-pdf-converter">Image to PDF Converter</h1>
+        </div>
+      </div>
+      <div>
+        <div>{{verb-widget-legal}}</div>
+      </div>
+    </div>
+    <div class="unity workflow-acrobat"></div>
+  </div>
+</main>

--- a/test/blocks/verb-widget/mocks/body-indd-to-pdf.html
+++ b/test/blocks/verb-widget/mocks/body-indd-to-pdf.html
@@ -1,0 +1,15 @@
+<main>
+  <div>
+    <div class="verb-widget indd-to-pdf">
+      <div>
+        <div>
+          <h1 id="indd-to-pdf-converter">INDD to PDF Converter</h1>
+        </div>
+      </div>
+      <div>
+        <div>{{verb-widget-legal}}</div>
+      </div>
+    </div>
+    <div class="unity workflow-acrobat"></div>
+  </div>
+</main>

--- a/test/blocks/verb-widget/mocks/body-psd-to-pdf.html
+++ b/test/blocks/verb-widget/mocks/body-psd-to-pdf.html
@@ -1,0 +1,15 @@
+<main>
+  <div>
+    <div class="verb-widget psd-to-pdf">
+      <div>
+        <div>
+          <h1 id="psd-to-pdf-converter">PSD to PDF Converter</h1>
+        </div>
+      </div>
+      <div>
+        <div>{{verb-widget-legal}}</div>
+      </div>
+    </div>
+    <div class="unity workflow-acrobat"></div>
+  </div>
+</main>

--- a/test/blocks/verb-widget/mocks/body-tiff-to-pdf.html
+++ b/test/blocks/verb-widget/mocks/body-tiff-to-pdf.html
@@ -1,0 +1,15 @@
+<main>
+  <div>
+    <div class="verb-widget tiff-to-pdf">
+      <div>
+        <div>
+          <h1 id="tiff-to-pdf-converter">TIFF to PDF Converter</h1>
+        </div>
+      </div>
+      <div>
+        <div>{{verb-widget-legal}}</div>
+      </div>
+    </div>
+    <div class="unity workflow-acrobat"></div>
+  </div>
+</main>

--- a/test/blocks/verb-widget/verb-widget-ios-accept.test.js
+++ b/test/blocks/verb-widget/verb-widget-ios-accept.test.js
@@ -1,0 +1,141 @@
+/* eslint-disable compat/compat */
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+
+const { default: init } = await import(
+  '../../../acrobat/blocks/verb-widget/verb-widget.js'
+);
+import { getConfig, setConfig } from 'https://main--milo--adobecom.aem.live/libs/utils/utils.js';
+
+const USER_AGENTS = {
+  iPhone:
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1',
+  Android:
+    'Mozilla/5.0 (Linux; Android 13; SM-G981B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Mobile Safari/537.36',
+  desktop:
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36',
+};
+
+const IOS_UNKNOWN_VERBS = [
+  'psd-to-pdf',
+  'ai-to-pdf',
+  'indd-to-pdf',
+  'image-to-pdf',
+  'bmp-to-pdf',
+  'gif-to-pdf',
+  'tiff-to-pdf',
+];
+
+describe('verb-widget iOS accept attribute tests', () => {
+  let placeholders;
+  let originalUserAgent;
+
+  beforeEach(async () => {
+    const placeholdersText = await readFile({ path: './mocks/placeholders.json' });
+    placeholders = JSON.parse(placeholdersText);
+
+    window.mph = {};
+    placeholders.data.forEach((item) => {
+      window.mph[item.key] = item.value;
+    });
+
+    document.head.innerHTML = await readFile({ path: './mocks/head.html' });
+    window.adobeIMS = { isSignedInUser: () => false };
+    originalUserAgent = window.navigator.userAgent;
+
+    sinon.stub(window, 'fetch').callsFake((x) => {
+      if (x.endsWith('.svg')) {
+        return window.fetch.wrappedMethod.call(window, x);
+      }
+      return Promise.resolve();
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window.navigator, 'userAgent', {
+      value: originalUserAgent,
+      configurable: true,
+    });
+    sinon.restore();
+  });
+
+  it('iOS + iOS-unknown extensions → accept="*/*" for all new MULTI_ALL_HEIC verbs', async () => {
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+
+    for (const verb of IOS_UNKNOWN_VERBS) {
+      Object.defineProperty(window.navigator, 'userAgent', {
+        value: USER_AGENTS.iPhone,
+        configurable: true,
+      });
+
+      document.body.innerHTML = await readFile({ path: `./mocks/body-${verb}.html` });
+      const block = document.body.querySelector('.verb-widget');
+      await init(block);
+
+      const accept = document.querySelector('#file-upload').getAttribute('accept');
+      expect(accept, `Expected */* for verb ${verb} on iOS`).to.equal('*/*');
+    }
+  });
+
+  it('non-iOS + iOS-unknown extensions → accept is NOT */* and includes .pdf', async () => {
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+
+    Object.defineProperty(window.navigator, 'userAgent', {
+      value: USER_AGENTS.desktop,
+      configurable: true,
+    });
+
+    document.body.innerHTML = await readFile({ path: './mocks/body-psd-to-pdf.html' });
+    const block = document.body.querySelector('.verb-widget');
+    await init(block);
+
+    const accept = document.querySelector('#file-upload').getAttribute('accept');
+    expect(accept).to.not.equal('*/*');
+    expect(accept).to.include('.pdf');
+  });
+
+  it('iOS + PDF-only verb (fillsign) → normal accept, not */*', async () => {
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+
+    Object.defineProperty(window.navigator, 'userAgent', {
+      value: USER_AGENTS.iPhone,
+      configurable: true,
+    });
+    window.browser = { ua: USER_AGENTS.iPhone };
+
+    document.body.innerHTML = await readFile({ path: './mocks/body-sign-pdf.html' });
+    const block = document.body.querySelector('.verb-widget');
+    await init(block);
+
+    const accept = document.querySelector('#file-upload');
+    // fillsign is a mobileApp verb — it does not render a file input on mobile
+    // but if the accept attribute exists it should NOT be */*
+    if (accept) {
+      expect(accept.getAttribute('accept')).to.not.equal('*/*');
+    } else {
+      // fillsign on mobile redirects to app store; no file input is rendered — this is expected
+      expect(block).to.exist;
+    }
+  });
+
+  it('iOS + jpg-to-pdf (MULTI_ALL contains iOS-unknown exts) → accept="*/*"', async () => {
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+
+    Object.defineProperty(window.navigator, 'userAgent', {
+      value: USER_AGENTS.iPhone,
+      configurable: true,
+    });
+
+    document.body.innerHTML = await readFile({ path: './mocks/body-jpg-to-pdf.html' });
+    const block = document.body.querySelector('.verb-widget');
+    await init(block);
+
+    const accept = document.querySelector('#file-upload').getAttribute('accept');
+    expect(accept).to.equal('*/*');
+  });
+});

--- a/test/blocks/verb-widget/verb-widget-ios-accept.test.js
+++ b/test/blocks/verb-widget/verb-widget-ios-accept.test.js
@@ -2,11 +2,11 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
+import { getConfig, setConfig } from 'https://main--milo--adobecom.aem.live/libs/utils/utils.js'; // eslint-disable-line import/no-unresolved, import/order
 
 const { default: init } = await import(
   '../../../acrobat/blocks/verb-widget/verb-widget.js'
 );
-import { getConfig, setConfig } from 'https://main--milo--adobecom.aem.live/libs/utils/utils.js';
 
 const USER_AGENTS = {
   iPhone:


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

- Added verb-widget-ios-accept.test.js to cover the iOS accept attribute behavior introduced in the getAcceptValue fix
- Added 7 mock HTML body files for the new image-to-PDF verbs (psd-to-pdf, ai-to-pdf, indd-to-pdf, image-to-pdf, bmp-to-pdf, gif-to-pdf, tiff-to-pdf)

## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-199357](https://jira.corp.adobe.com/browse/MWPW-199357)

## Test URLs
<!-- List the URLs where the changes can be tested -->
https://test-case-mwpw-199357--da-dc--adobecom.aem.page/acrobat/online/test/indd-to-pdf?unitylibs=stage
