### PR TITLE
[MWPW-199618]Fix incorrect font loading issue for ae_en

### DIFF
--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -207,7 +207,7 @@ const locales = {
   se: { ietf: 'sv-SE', tk: 'fpk1pcd.css' },
   ch_it: { ietf: 'it-CH', tk: 'bbf5pok.css' },
   tr: { ietf: 'tr-TR', tk: 'aaz7dvd.css' },
-  ae_en: { ietf: 'ar-EN', tk: 'pps7abe.css', dir: 'ltr', base: '' },
+  ae_en: { ietf: 'en', tk: 'pps7abe.css', dir: 'ltr', base: '' },
   uk: { ietf: 'en-GB', tk: 'pps7abe.css' },
   at: { ietf: 'de-AT', tk: 'vin7zsi.css' },
   cz: { ietf: 'cs-CZ', tk: 'aaz7dvd.css' },


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Fix incorrect font loading issue for ae_en

## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-199618](https://jira.corp.adobe.com/browse/MWPW-199618)

## Test URLs
<!-- List the URLs where the changes can be tested -->
- https://main--da-dc--adobecom.aem.live/ae_en/acrobat/online/ai-resume-builder
- https://mwpw-199618--da-dc--adobecom.aem.live/ae_en/acrobat/online/ai-resume-builder

Testing Notes:
Before:
<img width="1722" height="945" alt="before" src="https://github.com/user-attachments/assets/702779ca-24b6-404f-9292-fea4f5d4f612" />

After:

<img width="1728" height="829" alt="after" src="https://github.com/user-attachments/assets/6eb1d9cb-b76f-4dfa-a2f1-153f21d38602" />
