### PR TITLE
[MWPW-198873]Update typekits for Arabic and Hebrew locales

### DIFF
--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -214,10 +214,10 @@ const locales = {
   bg: { ietf: 'bg-BG', tk: 'aaz7dvd.css' },
   ru: { ietf: 'ru-RU', tk: 'aaz7dvd.css' },
   ua: { ietf: 'uk-UA', tk: 'aaz7dvd.css' },
-  il_he: { ietf: 'he', tk: 'nwq1mna.css', dir: 'rtl' },
-  ae_ar: { ietf: 'ar-AE', tk: 'nwq1mna.css', dir: 'rtl' },
+  il_he: { ietf: 'he', tk: 'nle2tdz.css', dir: 'rtl' },
+  ae_ar: { ietf: 'ar-AE', tk: 'dis2dpj.css', dir: 'rtl' },
   mena_ar: { ietf: 'ar', tk: 'dis2dpj.css', dir: 'rtl' },
-  sa_ar: { ietf: 'ar-SA', tk: 'nwq1mna.css', dir: 'rtl' },
+  sa_ar: { ietf: 'ar-SA', tk: 'dis2dpj.css', dir: 'rtl' },
   // Asia Pacific
   au: { ietf: 'en-AU', tk: 'pps7abe.css' },
   hk_en: { ietf: 'en-HK', tk: 'pps7abe.css', base: '' },
@@ -247,9 +247,9 @@ const locales = {
   ec: { ietf: 'es-EC', tk: 'oln4yqj.css' }, // Ecuador (Spanish Latin America)
   pr: { ietf: 'es-PR', tk: 'oln4yqj.css' }, // Puerto Rico (Spanish Latin America)
   gt: { ietf: 'es-GT', tk: 'oln4yqj.css' }, // Guatemala (Spanish Latin America)
-  eg_ar: { ietf: 'ar-EG', tk: 'nwq1mna.css', dir: 'rtl' }, // Egypt (Arabic)
-  kw_ar: { ietf: 'ar-KW', tk: 'nwq1mna.css', dir: 'rtl' }, // Kuwait (Arabic)
-  qa_ar: { ietf: 'ar-QA', tk: 'nwq1mna.css', dir: 'rtl' }, // Quatar (Arabic)
+  eg_ar: { ietf: 'ar-EG', tk: 'dis2dpj.css', dir: 'rtl' }, // Egypt (Arabic)
+  kw_ar: { ietf: 'ar-KW', tk: 'dis2dpj.css', dir: 'rtl' }, // Kuwait (Arabic)
+  qa_ar: { ietf: 'ar-QA', tk: 'dis2dpj.css', dir: 'rtl' }, // Quatar (Arabic)
   eg_en: { ietf: 'en-EG', tk: 'pps7abe.css', base: '' }, // Egypt (GB English)
   kw_en: { ietf: 'en-KW', tk: 'pps7abe.css', base: '' }, // Kuwait (GB English)
   qa_en: { ietf: 'en-QA', tk: 'pps7abe.css', base: '' }, // Qatar (GB English)


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
* Update typekit for all arabic locales (ae_ar, eg_ar, kw_ar, qa_ar, sa_ar) to dis2dpj.css mena_ar already has correct typekit
* Update typekit for il_he to nle2tdz.css

## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-198873](https://jira.corp.adobe.com/browse/MWPW-198873)

## Test URLs
<!-- List the URLs where the changes can be tested -->
- https://stage--da-dc--adobecom.aem.live/qa_ar/acrobat/online/compress-pdf
- https://mwpw-198873--da-dc--adobecom.aem.live/qa_ar/acrobat/online/compress-pdf

- https://stage--da-dc--adobecom.aem.live/il_he/acrobat/online/compress-pdf
- https://mwpw-198873--da-dc--adobecom.aem.live/il_he/acrobat/online/compress-pdf
