### PR TITLE
[MWPW-195799]Add guid to unity splunk dashboard and AA events

### DIFF
--- a/acrobat/blocks/study-marquee/study-marquee.js
+++ b/acrobat/blocks/study-marquee/study-marquee.js
@@ -164,10 +164,11 @@ async function loadAnalyticsAfterLCP(analyticsData) {
   const { verb, userAttempts } = analyticsData;
   try {
     const analyticsModule = await import('../../scripts/alloy/verb-widget.js');
-    const { default: verbAnalytics, reviewAnalytics, sendAnalyticsToSplunk } = analyticsModule;
+    const { default: verbAnalytics, reviewAnalytics, sendAnalyticsToSplunk, generateUploadGuid } = analyticsModule;
     window.analytics.verbAnalytics = verbAnalytics;
     window.analytics.reviewAnalytics = reviewAnalytics;
     window.analytics.sendAnalyticsToSplunk = sendAnalyticsToSplunk;
+    window.analytics.generateUploadGuid = generateUploadGuid;
     window.analytics.verbAnalytics('landing:shown', verb, { userAttempts });
     window.analytics.reviewAnalytics(verb);
   } catch (error) {
@@ -682,11 +683,13 @@ export default async function init(element) {
     const analyticsMap = {
       change: () => {
         exitFlag = false;
+        window.analytics.generateUploadGuid?.();
         handleAnalyticsEvent('choose-file:open', metadata, true, canSendDataToSplunk);
         registerTabCloseEvent(metadata, 'preuploading');
       },
       drop: () => {
         exitFlag = false;
+        window.analytics.generateUploadGuid?.();
         ['files-dropped', 'entry:clicked', 'discover:clicked'].forEach((analyticsEvent) => {
           handleAnalyticsEvent(analyticsEvent, metadata, true, canSendDataToSplunk);
         });

--- a/acrobat/blocks/study-marquee/study-marquee.js
+++ b/acrobat/blocks/study-marquee/study-marquee.js
@@ -165,7 +165,10 @@ async function loadAnalyticsAfterLCP(analyticsData) {
   try {
     const analyticsModule = await import('../../scripts/alloy/verb-widget.js');
     const {
-      default: verbAnalytics, reviewAnalytics, sendAnalyticsToSplunk, generateUploadGuid,
+      default: verbAnalytics,
+      reviewAnalytics,
+      sendAnalyticsToSplunk,
+      generateUploadGuid,
     } = analyticsModule;
     window.analytics.verbAnalytics = verbAnalytics;
     window.analytics.reviewAnalytics = reviewAnalytics;

--- a/acrobat/blocks/study-marquee/study-marquee.js
+++ b/acrobat/blocks/study-marquee/study-marquee.js
@@ -164,7 +164,9 @@ async function loadAnalyticsAfterLCP(analyticsData) {
   const { verb, userAttempts } = analyticsData;
   try {
     const analyticsModule = await import('../../scripts/alloy/verb-widget.js');
-    const { default: verbAnalytics, reviewAnalytics, sendAnalyticsToSplunk, generateUploadGuid } = analyticsModule;
+    const {
+      default: verbAnalytics, reviewAnalytics, sendAnalyticsToSplunk, generateUploadGuid,
+    } = analyticsModule;
     window.analytics.verbAnalytics = verbAnalytics;
     window.analytics.reviewAnalytics = reviewAnalytics;
     window.analytics.sendAnalyticsToSplunk = sendAnalyticsToSplunk;

--- a/acrobat/blocks/verb-marquee/verb-marquee.js
+++ b/acrobat/blocks/verb-marquee/verb-marquee.js
@@ -207,10 +207,11 @@ async function loadAnalyticsAfterLCP(analyticsData) {
   const { verb, userAttempts } = analyticsData;
   try {
     const analyticsModule = await import('../../scripts/alloy/verb-widget.js');
-    const { default: verbAnalytics, reviewAnalytics, sendAnalyticsToSplunk } = analyticsModule;
+    const { default: verbAnalytics, reviewAnalytics, sendAnalyticsToSplunk, generateUploadGuid } = analyticsModule;
     window.analytics.verbAnalytics = verbAnalytics;
     window.analytics.reviewAnalytics = reviewAnalytics;
     window.analytics.sendAnalyticsToSplunk = sendAnalyticsToSplunk;
+    window.analytics.generateUploadGuid = generateUploadGuid;
     window.analytics.verbAnalytics('landing:shown', verb, { userAttempts });
     window.analytics.reviewAnalytics(verb);
   } catch (error) {
@@ -810,11 +811,13 @@ export default async function init(element) {
     const analyticsMap = {
       change: () => {
         exitFlag = false;
+        window.analytics.generateUploadGuid?.();
         handleAnalyticsEvent('choose-file:open', metadata, true, canSendDataToSplunk);
         registerTabCloseEvent(metadata, 'preuploading');
       },
       drop: () => {
         exitFlag = false;
+        window.analytics.generateUploadGuid?.();
         ['files-dropped', 'entry:clicked', 'discover:clicked'].forEach((analyticsEvent) => {
           handleAnalyticsEvent(analyticsEvent, metadata, true, canSendDataToSplunk);
         });

--- a/acrobat/blocks/verb-marquee/verb-marquee.js
+++ b/acrobat/blocks/verb-marquee/verb-marquee.js
@@ -207,7 +207,9 @@ async function loadAnalyticsAfterLCP(analyticsData) {
   const { verb, userAttempts } = analyticsData;
   try {
     const analyticsModule = await import('../../scripts/alloy/verb-widget.js');
-    const { default: verbAnalytics, reviewAnalytics, sendAnalyticsToSplunk, generateUploadGuid } = analyticsModule;
+    const {
+      default: verbAnalytics, reviewAnalytics, sendAnalyticsToSplunk, generateUploadGuid,
+    } = analyticsModule;
     window.analytics.verbAnalytics = verbAnalytics;
     window.analytics.reviewAnalytics = reviewAnalytics;
     window.analytics.sendAnalyticsToSplunk = sendAnalyticsToSplunk;

--- a/acrobat/blocks/verb-marquee/verb-marquee.js
+++ b/acrobat/blocks/verb-marquee/verb-marquee.js
@@ -208,7 +208,10 @@ async function loadAnalyticsAfterLCP(analyticsData) {
   try {
     const analyticsModule = await import('../../scripts/alloy/verb-widget.js');
     const {
-      default: verbAnalytics, reviewAnalytics, sendAnalyticsToSplunk, generateUploadGuid,
+      default: verbAnalytics,
+      reviewAnalytics,
+      sendAnalyticsToSplunk,
+      generateUploadGuid,
     } = analyticsModule;
     window.analytics.verbAnalytics = verbAnalytics;
     window.analytics.reviewAnalytics = reviewAnalytics;

--- a/acrobat/blocks/verb-widget/verb-widget.js
+++ b/acrobat/blocks/verb-widget/verb-widget.js
@@ -374,10 +374,11 @@ async function loadAnalyticsAfterLCP(analyticsData) {
   const { verb, userAttempts } = analyticsData;
   try {
     const analyticsModule = await import('../../scripts/alloy/verb-widget.js');
-    const { default: verbAnalytics, reviewAnalytics, sendAnalyticsToSplunk } = analyticsModule;
+    const { default: verbAnalytics, reviewAnalytics, sendAnalyticsToSplunk, generateUploadGuid } = analyticsModule;
     window.analytics.verbAnalytics = verbAnalytics;
     window.analytics.reviewAnalytics = reviewAnalytics;
     window.analytics.sendAnalyticsToSplunk = sendAnalyticsToSplunk;
+    window.analytics.generateUploadGuid = generateUploadGuid;
     window.analytics.verbAnalytics('landing:shown', verb, { userAttempts });
     window.analytics.reviewAnalytics(verb);
   } catch (error) {
@@ -870,11 +871,13 @@ export default async function init(element) {
     const analyticsMap = {
       change: () => {
         exitFlag = false;
+        window.analytics.generateUploadGuid?.();
         handleAnalyticsEvent('choose-file:open', metadata, true, canSendDataToSplunk);
         registerTabCloseEvent(metadata, 'preuploading');
       },
       drop: () => {
         exitFlag = false;
+        window.analytics.generateUploadGuid?.();
         ['files-dropped', 'entry:clicked', 'discover:clicked'].forEach((analyticsEvent) => {
           handleAnalyticsEvent(analyticsEvent, metadata, true, canSendDataToSplunk);
         });

--- a/acrobat/blocks/verb-widget/verb-widget.js
+++ b/acrobat/blocks/verb-widget/verb-widget.js
@@ -375,7 +375,10 @@ async function loadAnalyticsAfterLCP(analyticsData) {
   try {
     const analyticsModule = await import('../../scripts/alloy/verb-widget.js');
     const {
-      default: verbAnalytics, reviewAnalytics, sendAnalyticsToSplunk, generateUploadGuid,
+      default: verbAnalytics,
+      reviewAnalytics,
+      sendAnalyticsToSplunk,
+      generateUploadGuid,
     } = analyticsModule;
     window.analytics.verbAnalytics = verbAnalytics;
     window.analytics.reviewAnalytics = reviewAnalytics;

--- a/acrobat/blocks/verb-widget/verb-widget.js
+++ b/acrobat/blocks/verb-widget/verb-widget.js
@@ -374,7 +374,9 @@ async function loadAnalyticsAfterLCP(analyticsData) {
   const { verb, userAttempts } = analyticsData;
   try {
     const analyticsModule = await import('../../scripts/alloy/verb-widget.js');
-    const { default: verbAnalytics, reviewAnalytics, sendAnalyticsToSplunk, generateUploadGuid } = analyticsModule;
+    const {
+      default: verbAnalytics, reviewAnalytics, sendAnalyticsToSplunk, generateUploadGuid,
+    } = analyticsModule;
     window.analytics.verbAnalytics = verbAnalytics;
     window.analytics.reviewAnalytics = reviewAnalytics;
     window.analytics.sendAnalyticsToSplunk = sendAnalyticsToSplunk;

--- a/acrobat/scripts/alloy/verb-widget.js
+++ b/acrobat/scripts/alloy/verb-widget.js
@@ -71,6 +71,13 @@ function eventData(metaData, { appReferrer: referrer, trackingId: tracking }) {
   };
 }
 
+let uploadGuid;
+
+export function generateUploadGuid() {
+  // eslint-disable-next-line compat/compat
+  uploadGuid = crypto.randomUUID();
+}
+
 function createPayloadForSplunk(metaData) {
   const {
     verb, eventName, noOfFiles, uploadTime, type, size, count, workflowStep,
@@ -111,6 +118,7 @@ function createPayloadForSplunk(metaData) {
       type: [`${localStorage['unity.user'] ? 'frictionless_return_user' : 'frictionless_new_user'}`],
       ...(userAttempts && { return_user_type: userAttempts }),
     },
+    upload: { guid: uploadGuid },
     error: errorData ? {
       type: errorData.code,
       ...(errorData.subCode && { subCode: errorData.subCode }),


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
- Introduce generateUploadGuid() in acrobat/scripts/alloy/verb-widget.js
  using crypto.randomUUID() to generate a unique ID per upload session
- Include GUID in Splunk payload under upload.guid to enable cross-event
  correlation for a single upload session in the dashboard
- Call generateUploadGuid() on change and drop events across all three
  blocks before analytics events fire, ensuring GUID is set at upload start
- Export generateUploadGuid via window.analytics in study-marquee,
  verb-marquee, and verb-widget blocks for consistent access
- Use optional chaining (?.) when invoking to handle analytics module
  not being loaded

## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-195799](https://jira.corp.adobe.com/browse/MWPW-195799)

## Test URLs
<!-- List the URLs where the changes can be tested -->
- https://stage--da-dc--adobecom.aem.live/acrobat/online/compress-pdf
- https://mwpw-195799--da-dc--adobecom.aem.live/acrobat/online/compress-pdf
