### PR TITLE
[MWPW-202912]Remove 3 second delay before uploaded event for all verbs

### DIFF
--- a/acrobat/blocks/verb-widget/verb-widget.js
+++ b/acrobat/blocks/verb-widget/verb-widget.js
@@ -788,7 +788,7 @@ export default async function init(element) {
 
   function handleUploadedEvent(data, attempts, cookieExp, canSendDataToSplunk) {
     exitFlag = true;
-    if (LIMITS[VERB]?.noRedirectTimeout) {
+    if (LIMITS[VERB]?.noRedirectTimeout ?? true) {
       window.dispatchEvent(redirectReady);
     } else {
       setTimeout(() => {


### PR DESCRIPTION
## Summary

Removes the 3-second wait before the `job:uploaded` analytics event for **all** verbs in `verb-widget.js`.

Previously, only verbs with `noRedirectTimeout: true` in their `LIMITS` config (`word-to-pdf`, `jpg-to-pdf`) dispatched `redirectReady` immediately; every other verb waited up to 3 seconds via a `setTimeout` fallback before redirecting.

## Changes

- In `handleUploadedEvent` ([verb-widget.js](acrobat/blocks/verb-widget/verb-widget.js)), defaulted the `noRedirectTimeout` config flag to `true`:
  ```js
  if (LIMITS[VERB]?.noRedirectTimeout ?? true) {
  ```
- The `setTimeout(..., 3000)` fallback branch and its Lana warning log are **kept intact** — they're simply no longer reached, so the code can be re-enabled per-verb by setting `noRedirectTimeout: false`.

## Impact

- All verbs now dispatch `redirectReady` immediately on the `uploaded` event, removing the redirect delay.
- No code removed; behavior is fully config-driven and reversible.

Resolves: [MWPW-202912](https://jira.corp.adobe.com/browse/MWPW-202912)

## Test URLs

- main: https://main--da-dc--adobecom.aem.live/acrobat/online/compress-pdf
- branch: https://mwpw-202912--da-dc--adobecom.aem.live/acrobat/online/compress-pdf

