### PR TITLE
[MWPW-202884] Add early prefetch for excel-to-pdf and ppt-to-pdf

### DIFF
--- a/acrobat/blocks/verb-widget/verb-widget.js
+++ b/acrobat/blocks/verb-widget/verb-widget.js
@@ -158,13 +158,26 @@ function initiatePrefetch(url) {
   }
 }
 
-function buildWordToPdfEarlyPrefetchUrl() {
+// Shared dummy asset used to warm the destination Acrobat web app before the real
+// upload. TODO(MWPW-202884): swap in per-verb sample assets once they are available.
+const EARLY_PREFETCH_DUMMY_ASSET = 'urn%3Aaaid%3Asc%3AUS%3A1111111%7CSample%20word%20file_WordtoPDF.docx%7C386919%7Capplication%2Fvnd.openxmlformats-officedocument.wordprocessingml.document';
+
+// Per-verb configuration for the early prefetch of the destination Acrobat page.
+// `path` is the URL segment after the locale (word-to-pdf ships the `/av` app route).
+const EARLY_PREFETCH_CONFIG = {
+  'word-to-pdf': { path: 'word-to-pdf/av', clientLocation: 'word-to-pdf', assets: EARLY_PREFETCH_DUMMY_ASSET },
+  'excel-to-pdf': { path: 'excel-to-pdf', clientLocation: 'excel-to-pdf', assets: EARLY_PREFETCH_DUMMY_ASSET },
+  'ppt-to-pdf': { path: 'ppt-to-pdf', clientLocation: 'ppt-to-pdf', assets: EARLY_PREFETCH_DUMMY_ASSET },
+};
+
+function buildEarlyPrefetchUrl(verb) {
+  const config = EARLY_PREFETCH_CONFIG[verb];
+  if (!config) return null;
   const langFromPath = window.location.pathname.split('/')[1];
   const locale = localeMap[langFromPath] || 'en-us';
   const [languageCode, languageRegion] = locale.split('-');
   const domain = DC_ENV === 'prod' ? 'acrobat.adobe.com' : 'stage.acrobat.adobe.com';
-  const dummyAssets = 'urn%3Aaaid%3Asc%3AUS%3A1111111%7CSample%20word%20file_WordtoPDF.docx%7C386919%7Capplication%2Fvnd.openxmlformats-officedocument.wordprocessingml.document';
-  return `https://${domain}/${languageRegion}/${languageCode}/word-to-pdf/av?x_api_client_id=unity&x_api_client_location=word-to-pdf&user=frictionless_return_user&attempts=2%2B#assets=${dummyAssets}`;
+  return `https://${domain}/${languageRegion}/${languageCode}/${config.path}?x_api_client_id=unity&x_api_client_location=${config.clientLocation}&user=frictionless_return_user&attempts=2%2B#assets=${config.assets}`;
 }
 
 function redDirLink(verb) {
@@ -829,9 +842,9 @@ export default async function init(element) {
 
   window.prefetchTargetUrl = null;
 
-  if (VERB === 'word-to-pdf') {
+  if (EARLY_PREFETCH_CONFIG[VERB]) {
     const triggerEarlyPrefetch = () => {
-      initiatePrefetch(buildWordToPdfEarlyPrefetchUrl());
+      initiatePrefetch(buildEarlyPrefetchUrl(VERB));
       prefetchTarget();
     };
     document.addEventListener('click', triggerEarlyPrefetch, { once: true });

--- a/acrobat/blocks/verb-widget/verb-widget.js
+++ b/acrobat/blocks/verb-widget/verb-widget.js
@@ -16,7 +16,12 @@ let soloClicked;
 const fallBack = 'https://www.adobe.com/go/acrobat-overview';
 const EOLBrowserPage = 'https://acrobat.adobe.com/home/index-browser-eol.html';
 const demoPath = 'blob/JTdCJTIyc291cmNlJTIyJTNBJTIyY2RuJTIyJTJDJTIyZmlsZVBhdGglMjIlM0ElMjIlMkZkYy1maWxlczItZHJvcGluJTJGZGVtby1maWxlcyUyRmVuLVVTJTJGY2hhdC1wZGYtZGVtby12NCUyRmNoYXQtcGRmLWRlbW8tdjQucGRmJTIyJTJDJTIyaXRlbU5hbWUlMjIlM0ElMjJBSSUyMEFzc2lzdGFudCUyMGRlbW8lMjBmaWxlLnBkZiUyMiUyQyUyMm5hbWUlMjIlM0ElMjJjaGF0LXBkZi1kZW1vLXY0JTIyJTJDJTIyaXRlbVR5cGUlMjIlM0ElMjJhcHBsaWNhdGlvbiUyRnBkZiUyMiU3RA/?defaultRHPFeature=verb-qanda&x_api_client_id=ChatPDFTryDemoFile&x_api_client_location=chat_pdf&try-ai-demo=true&demo-mode=true&promoid=HHJ4X8CS&mv=product&mv2=acrobat-web';
-
+const EARLY_PREFETCH_DUMMY_ASSET = 'urn%3Aaaid%3Asc%3AUS%3A1111111%7CSample%20word%20file_WordtoPDF.docx%7C386919%7Capplication%2Fvnd.openxmlformats-officedocument.wordprocessingml.document';
+const EARLY_PREFETCH_CONFIG = {
+  'word-to-pdf': { path: 'word-to-pdf/av', clientLocation: 'word-to-pdf', assets: EARLY_PREFETCH_DUMMY_ASSET },
+  'excel-to-pdf': { path: 'excel-to-pdf', clientLocation: 'excel-to-pdf', assets: EARLY_PREFETCH_DUMMY_ASSET },
+  'ppt-to-pdf': { path: 'ppt-to-pdf', clientLocation: 'ppt-to-pdf', assets: EARLY_PREFETCH_DUMMY_ASSET },
+};
 const redirectReady = new CustomEvent('DCUnity:RedirectReady');
 
 const verbRedirMap = {
@@ -157,18 +162,6 @@ function initiatePrefetch(url) {
     window.prefetchTargetUrl = url;
   }
 }
-
-// Shared dummy asset used to warm the destination Acrobat web app before the real
-// upload. TODO(MWPW-202884): swap in per-verb sample assets once they are available.
-const EARLY_PREFETCH_DUMMY_ASSET = 'urn%3Aaaid%3Asc%3AUS%3A1111111%7CSample%20word%20file_WordtoPDF.docx%7C386919%7Capplication%2Fvnd.openxmlformats-officedocument.wordprocessingml.document';
-
-// Per-verb configuration for the early prefetch of the destination Acrobat page.
-// `path` is the URL segment after the locale (word-to-pdf ships the `/av` app route).
-const EARLY_PREFETCH_CONFIG = {
-  'word-to-pdf': { path: 'word-to-pdf/av', clientLocation: 'word-to-pdf', assets: EARLY_PREFETCH_DUMMY_ASSET },
-  'excel-to-pdf': { path: 'excel-to-pdf', clientLocation: 'excel-to-pdf', assets: EARLY_PREFETCH_DUMMY_ASSET },
-  'ppt-to-pdf': { path: 'ppt-to-pdf', clientLocation: 'ppt-to-pdf', assets: EARLY_PREFETCH_DUMMY_ASSET },
-};
 
 function buildEarlyPrefetchUrl(verb) {
   const config = EARLY_PREFETCH_CONFIG[verb];

--- a/test/blocks/verb-widget/verb-widget-prefetch.test.js
+++ b/test/blocks/verb-widget/verb-widget-prefetch.test.js
@@ -1,0 +1,90 @@
+/* eslint-disable compat/compat */
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+
+const { default: init } = await import(
+  '../../../acrobat/blocks/verb-widget/verb-widget.js'
+);
+import { getConfig, setConfig } from 'https://main--milo--adobecom.aem.live/libs/utils/utils.js';
+
+// Verbs wired for early prefetch and the URL fragments each should produce.
+const PREFETCH_VERBS = [
+  { verb: 'word-to-pdf', pathFragment: '/word-to-pdf/av?', clientLocation: 'word-to-pdf' },
+  { verb: 'excel-to-pdf', pathFragment: '/excel-to-pdf?', clientLocation: 'excel-to-pdf' },
+  { verb: 'ppt-to-pdf', pathFragment: '/ppt-to-pdf?', clientLocation: 'ppt-to-pdf' },
+];
+
+const getPrefetchLinks = () => [...document.head.querySelectorAll('link[rel="prefetch"]')];
+
+describe('verb-widget early prefetch', () => {
+  beforeEach(async () => {
+    const placeholdersText = await readFile({ path: './mocks/placeholders.json' });
+    const placeholders = JSON.parse(placeholdersText);
+    window.mph = {};
+    placeholders.data.forEach((item) => { window.mph[item.key] = item.value; });
+
+    document.head.innerHTML = await readFile({ path: './mocks/head.html' });
+    window.adobeIMS = { isSignedInUser: () => false };
+
+    // Drain any `once` prefetch listeners left on `document` by a previous test
+    // (e.g. an unused dragover handler), then reset the module's window state so
+    // each test starts with no pending listeners and a clean slate.
+    document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    document.dispatchEvent(new DragEvent('dragover', { bubbles: true }));
+    window.prefetchTargetUrl = null;
+    window.prefetchTargetLoaded = false;
+    getPrefetchLinks().forEach((link) => link.remove());
+
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    getPrefetchLinks().forEach((link) => link.remove());
+  });
+
+  PREFETCH_VERBS.forEach(({ verb, pathFragment, clientLocation }) => {
+    it(`prefetches the destination page on first interaction for ${verb}`, async () => {
+      document.body.innerHTML = await readFile({ path: `./mocks/body-${verb}.html` });
+      const block = document.body.querySelector('.verb-widget');
+      await init(block);
+
+      // No prefetch until the user interacts.
+      expect(getPrefetchLinks()).to.have.lengthOf(0);
+
+      document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+      const links = getPrefetchLinks();
+      expect(links).to.have.lengthOf(1);
+      const { href } = links[0];
+      expect(href).to.include(pathFragment);
+      expect(href).to.include(`x_api_client_location=${clientLocation}`);
+      expect(href).to.include('x_api_client_id=unity');
+      expect(href).to.include('user=frictionless_return_user');
+      // Shared dummy asset used to warm the destination app.
+      expect(href).to.include('assets=urn%3Aaaid%3Asc%3AUS%3A1111111');
+    });
+  });
+
+  it('also prefetches on dragover for word-to-pdf', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/body-word-to-pdf.html' });
+    const block = document.body.querySelector('.verb-widget');
+    await init(block);
+
+    document.dispatchEvent(new DragEvent('dragover', { bubbles: true }));
+
+    expect(getPrefetchLinks()).to.have.lengthOf(1);
+  });
+
+  it('does not prefetch for a verb without early-prefetch config', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/body-compress-pdf.html' });
+    const block = document.body.querySelector('.verb-widget');
+    await init(block);
+
+    document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(getPrefetchLinks()).to.have.lengthOf(0);
+  });
+});

--- a/test/blocks/verb-widget/verb-widget-prefetch.test.js
+++ b/test/blocks/verb-widget/verb-widget-prefetch.test.js
@@ -2,11 +2,11 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
+import { getConfig, setConfig } from 'https://main--milo--adobecom.aem.live/libs/utils/utils.js'; // eslint-disable-line import/no-unresolved
 
 const { default: init } = await import(
   '../../../acrobat/blocks/verb-widget/verb-widget.js'
 );
-import { getConfig, setConfig } from 'https://main--milo--adobecom.aem.live/libs/utils/utils.js';
 
 // Verbs wired for early prefetch and the URL fragments each should produce.
 const PREFETCH_VERBS = [

--- a/test/blocks/verb-widget/verb-widget-prefetch.test.js
+++ b/test/blocks/verb-widget/verb-widget-prefetch.test.js
@@ -8,7 +8,6 @@ const { default: init } = await import(
   '../../../acrobat/blocks/verb-widget/verb-widget.js'
 );
 
-// Verbs wired for early prefetch and the URL fragments each should produce.
 const PREFETCH_VERBS = [
   { verb: 'word-to-pdf', pathFragment: '/word-to-pdf/av?', clientLocation: 'word-to-pdf' },
   { verb: 'excel-to-pdf', pathFragment: '/excel-to-pdf?', clientLocation: 'excel-to-pdf' },
@@ -27,9 +26,6 @@ describe('verb-widget early prefetch', () => {
     document.head.innerHTML = await readFile({ path: './mocks/head.html' });
     window.adobeIMS = { isSignedInUser: () => false };
 
-    // Drain any `once` prefetch listeners left on `document` by a previous test
-    // (e.g. an unused dragover handler), then reset the module's window state so
-    // each test starts with no pending listeners and a clean slate.
     document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     document.dispatchEvent(new DragEvent('dragover', { bubbles: true }));
     window.prefetchTargetUrl = null;
@@ -51,7 +47,6 @@ describe('verb-widget early prefetch', () => {
       const block = document.body.querySelector('.verb-widget');
       await init(block);
 
-      // No prefetch until the user interacts.
       expect(getPrefetchLinks()).to.have.lengthOf(0);
 
       document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
@@ -63,7 +58,6 @@ describe('verb-widget early prefetch', () => {
       expect(href).to.include(`x_api_client_location=${clientLocation}`);
       expect(href).to.include('x_api_client_id=unity');
       expect(href).to.include('user=frictionless_return_user');
-      // Shared dummy asset used to warm the destination app.
       expect(href).to.include('assets=urn%3Aaaid%3Asc%3AUS%3A1111111');
     });
   });


### PR DESCRIPTION


Generalize the word-to-pdf early-prefetch logic in verb-widget into a reusable, config-driven helper so the destination Acrobat page is warmed on first user interaction for additional verbs.
- Replace buildWordToPdfEarlyPrefetchUrl() with buildEarlyPrefetchUrl(verb), driven by an EARLY_PREFETCH_CONFIG map (path + client location + dummy asset per verb)
- Enable early prefetch for excel-to-pdf and ppt-to-pdf (word-to-pdf keeps its existing /av route)
- Gate the click/dragover prefetch trigger on the config map instead of a hardcoded word-to-pdf check
- Add verb-widget-prefetch.test.js covering prefetch URLs for all three verbs, the dragover trigger, and the no-prefetch case for unconfigured verbs

## Description
<!-- Provide a brief description of the changes in this PR -->

## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-202884](https://jira.corp.adobe.com/browse/MWPW-202884)

## Test URLs
<!-- List the URLs where the changes can be tested -->
- https://main--da-dc--adobecom.aem.live/acrobat/online/compress-pdf
- https://mwpw-202884--da-dc--adobecom.aem.live/acrobat/online/compress-pdf
- https://mwpw-202884--da-dc--adobecom.aem.live/acrobat/online/ppt-to-pdf
- https://mwpw-202884--da-dc--adobecom.aem.live/acrobat/online/excel-to-pdf
