### PR TITLE
[MWPW-197746] New block for client side upload of file

### DIFF
--- a/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.css
+++ b/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.css
@@ -1,0 +1,351 @@
+/*
+ * verb-widget-client-upload.css
+ * Mirrors verb-widget layout/typography. Adds progress-bar styles.
+ */
+
+:root {
+  --consonant-font-family: 'Adobe Clean', adobe-clean, 'Trebuchet MS', sans-serif;
+  --consonant-color-white: #fff;
+  --consonant-color: #2c2c2c;
+  --consonant-color-gray-300: #d5d5d5;
+  --consonant-color-gray-700: #464646;
+  --consonant-link-color: #1473e6;
+  --consonant-link-color-hover: #0d66d0;
+
+  --consonant-spacing-xxs: 8px;
+  --consonant-spacing-xs: 16px;
+  --consonant-spacing-s: 24px;
+  --consonant-spacing-m: 32px;
+
+  --consonant-radius-xl: 20px;
+
+  --verb-wrapper-border-width: 3px;
+  --verb-wrapper-padding-y: var(--consonant-spacing-s);
+  --verb-wrapper-padding-x: var(--consonant-spacing-s);
+  --verb-wrapper-min-height: auto;
+  --verb-wrapper-width: 1008px;
+  --verb-wrapper-max-width: calc(var(--verb-wrapper-width) - ((var(--verb-wrapper-padding-x) * 2) + var(--verb-wrapper-border-width) * 2));
+
+  --verb-widget-padding: var(--consonant-spacing-m) var(--consonant-spacing-xs);
+  --verb-widget-min-height: 528px;
+  --verb-widget-image-width: 120px;
+
+  --consonant-heading-xxl-size: 36px;
+  --consonant-heading-xxl-fw: 700;
+  --consonant-body-m-size: 18px;
+  --consonant-body-xxs-size: 12px;
+  --consonant-button-l-label-size: 19px;
+
+  --gnav-height: 115px;
+  --footer-height: calc(72px + var(--consonant-spacing-s));
+
+  @media (min-width: 835px) {
+    --verb-widget-min-height: 360px;
+    --verb-wrapper-min-height: auto;
+    --verb-widget-padding: 32px 40px;
+    --verb-widget-image-width: 160px;
+    --verb-wrapper-padding-y: 40px;
+    --verb-wrapper-padding-x: 40px;
+  }
+
+  @media (min-width: 1200px) {
+    --verb-widget-padding: 32px 96px;
+    --verb-wrapper-min-height: 475px;
+    --verb-widget-image-width: 200px;
+    --verb-wrapper-padding-x: 96px;
+    --consonant-heading-xxl-size: 44px;
+  }
+
+  @media (min-width: 1392px) {
+    --verb-wrapper-width: 1200px;
+  }
+}
+
+/* ── Block shell ────────────────────────────────────────────────────────────── */
+
+.verb-widget-client-upload {
+  background-color: #fff;
+  background-image: linear-gradient(180deg, #eb1000 0%, #f79b94 46%, #fff 78%);
+  padding: var(--verb-widget-padding);
+  min-height: var(--verb-widget-min-height);
+  color: transparent;
+}
+
+.verb-widget-client-upload.ready {
+  color: initial;
+}
+
+/* ── Drop zone wrapper ──────────────────────────────────────────────────────── */
+
+.verb-wrapper {
+  max-width: var(--verb-wrapper-max-width);
+  padding: var(--verb-wrapper-padding-y) var(--verb-wrapper-padding-x);
+  border: var(--verb-wrapper-border-width) dashed var(--consonant-color-gray-300);
+  border-radius: var(--consonant-radius-xl);
+  min-height: var(--verb-wrapper-min-height);
+  background-color: #fff;
+  cursor: pointer;
+  margin-inline: auto;
+}
+
+.verb-wrapper:hover {
+  border-color: #909090;
+}
+
+.verb-wrapper.dragging {
+  background-color: #ecf5ff;
+  border: 3px solid #0265dc;
+}
+
+/* ── Layout ─────────────────────────────────────────────────────────────────── */
+
+.verb-row {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  min-height: 100%;
+}
+
+.verb-col {
+  flex: 100%;
+}
+
+.verb-col.right {
+  display: flex;
+  justify-content: center;
+}
+
+/* ── Header (Acrobat icon + "Adobe Acrobat") ────────────────────────────────── */
+
+.verb-header {
+  display: flex;
+  align-items: center;
+  gap: var(--consonant-spacing-xxs);
+  margin-bottom: var(--consonant-spacing-xxs);
+}
+
+.acrobat-icon {
+  display: inline-flex;
+  width: 42px;
+  height: 40px;
+}
+
+.acrobat-icon svg,
+.icon-verb {
+  width: 100%;
+  height: 100%;
+}
+
+.verb-title {
+  font-family: var(--consonant-font-family);
+  font-size: var(--consonant-body-m-size);
+  font-weight: 700;
+  color: var(--consonant-color);
+}
+
+/* ── Heading ────────────────────────────────────────────────────────────────── */
+
+.verb-heading {
+  font-family: var(--consonant-font-family);
+  font-size: var(--consonant-heading-xxl-size);
+  font-weight: var(--consonant-heading-xxl-fw);
+  line-height: 125%;
+  color: var(--consonant-color);
+  margin: var(--consonant-spacing-xxs) 0 var(--consonant-spacing-s);
+}
+
+/* ── Body copy ──────────────────────────────────────────────────────────────── */
+
+.verb-copy {
+  font-family: var(--consonant-font-family);
+  font-size: var(--consonant-body-m-size);
+  line-height: 150%;
+  color: var(--consonant-color);
+  margin: 0 0 var(--consonant-spacing-s);
+}
+
+/* ── CTA button ─────────────────────────────────────────────────────────────── */
+
+.verb-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 24px 14px;
+  background: #1473e6;
+  color: #fff;
+  border: none;
+  border-radius: 24px;
+  font-family: var(--consonant-font-family);
+  font-size: var(--consonant-button-l-label-size);
+  font-weight: 700;
+  cursor: pointer;
+  margin-bottom: var(--consonant-spacing-s);
+  transition: background 0.15s;
+}
+
+.verb-cta:hover {
+  background: #0d66d0;
+}
+
+.verb-cta:disabled {
+  background: #747474;
+  cursor: default;
+}
+
+.upload-icon {
+  width: 22px;
+  height: 22px;
+  flex-shrink: 0;
+}
+
+.hide {
+  display: none !important;
+}
+
+/* ── Error state ────────────────────────────────────────────────────────────── */
+
+.error {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  background: #fff4f4;
+  border: 1px solid #eb1000;
+  border-radius: 8px;
+  padding: var(--consonant-spacing-xxs) var(--consonant-spacing-xs);
+  margin-bottom: var(--consonant-spacing-s);
+}
+
+.error.hide {
+  display: none;
+}
+
+.verb-errorText {
+  flex: 1;
+  font-family: var(--consonant-font-family);
+  font-size: 14px;
+  color: #eb1000;
+  margin: 0;
+}
+
+.verb-errorBtn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+  color: #eb1000;
+  padding: 0;
+  line-height: 1;
+}
+
+/* ── Progress bar ───────────────────────────────────────────────────────────── */
+/*
+ * This section has no equivalent in verb-widget because Unity SDK manages
+ * its own loading/progress UI inside the DC Hosted iframe.
+ * In this client-side block we own the full upload lifecycle, so we build
+ * our own progress indicator here.
+ */
+
+.upload-progress {
+  display: flex;
+  flex-direction: column;
+  gap: var(--consonant-spacing-xxs);
+  margin-bottom: var(--consonant-spacing-s);
+}
+
+.upload-progress-label {
+  font-family: var(--consonant-font-family);
+  font-size: 14px;
+  color: var(--consonant-color-gray-700);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 340px;
+}
+
+.upload-progress-bar {
+  width: 100%;
+  max-width: 340px;
+  height: 6px;
+  background: var(--consonant-color-gray-300);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.upload-progress-fill {
+  height: 100%;
+  width: 0%;
+  background: #1473e6;
+  border-radius: 3px;
+  transition: width 0.2s ease;
+}
+
+.upload-cancel-btn {
+  align-self: flex-start;
+  background: none;
+  border: 1px solid var(--consonant-color-gray-300);
+  border-radius: 16px;
+  padding: 4px 14px;
+  font-family: var(--consonant-font-family);
+  font-size: 14px;
+  color: var(--consonant-color-gray-700);
+  cursor: pointer;
+  margin-top: 2px;
+}
+
+.upload-cancel-btn:hover {
+  border-color: #909090;
+}
+
+/* ── Image column ────────────────────────────────────────────────────────────── */
+
+.verb-image {
+  width: var(--verb-widget-image-width);
+}
+
+.verb-image svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+/* ── Footer ─────────────────────────────────────────────────────────────────── */
+
+.verb-footer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: var(--consonant-spacing-s);
+}
+
+.security-icon {
+  display: flex;
+  padding: 8.5px 11px;
+}
+
+.verb-legal-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.verb-legal {
+  display: inline-block;
+  color: var(--consonant-color-gray-700);
+  margin: 0;
+  font-size: var(--consonant-body-xxs-size);
+  line-height: 150%;
+}
+
+.verb-legal-two {
+  margin-top: 0;
+}
+
+.verb-legal-url {
+  text-decoration: underline;
+  color: var(--consonant-link-color);
+}
+
+.verb-legal-url:hover {
+  color: var(--consonant-link-color-hover);
+}

--- a/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.css
+++ b/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.css
@@ -1,81 +1,210 @@
-/*
- * verb-widget-client-upload.css
- * Mirrors verb-widget layout/typography. Adds progress-bar styles.
- */
-
 :root {
-  --consonant-font-family: 'Adobe Clean', adobe-clean, 'Trebuchet MS', sans-serif;
-  --consonant-color-white: #fff;
-  --consonant-color: #2c2c2c;
-  --consonant-color-gray-300: #d5d5d5;
+  /* Consonant Variables */
+  --consonant-font-family:'Adobe Clean', adobe-clean, 'Trebuchet MS', sans-serif;
+  --consonant-color-white: #FFF;
+  --consonant-color: #2C2C2C;
+  --consonant-logo-color: var(--consonant-color);
+  --consonant-logo-font-family: var(--consonant-font-family);
+  --consonant-color-gray-300: #D5D5D5;
   --consonant-color-gray-700: #464646;
-  --consonant-link-color: #1473e6;
-  --consonant-link-color-hover: #0d66d0;
+  --consonant-link-color: #1473E6;
+  --consonant-link-color-hover: #0D66D0;
+  --consonant-button-accent-action-bg: var(--consonant-link-color);
+  --consonant-button-accent-action-bg-hover: var(--consonant-link-color-hover);
+  --consonant-button-accent-action-text: var(--consonant-color-white);
 
-  --consonant-spacing-xxs: 8px;
-  --consonant-spacing-xs: 16px;
-  --consonant-spacing-s: 24px;
-  --consonant-spacing-m: 32px;
+  /* Logo type M */
+  --consonant-logo-m-img-width: 41.5px;
+  --consonant-logo-m-img-height: 40px;
+  --consonant-logo-m-size: 27px;
+  --consonant-logo-m-lh: 125%;
+  --consonant-logo-m-ls: 0%;
+  --consonant-logo-m-fw: 700;
 
-  --consonant-radius-xl: 20px;
+  /* Heading type XXL */
+  --consonant-heading-xxl-size: 36px;
+  --consonant-heading-xxl-lh: 125%;
+  --consonant-heading-xxl-ls: 0%;
+  --consonant-heading-xxl-fw: 700;
 
-  --verb-wrapper-border-width: 3px;
+  /* Body type M */
+  --consonant-body-m-size: 18px;
+  --consonant-body-m-lh: 150%;
+  --consonant-body-ls: 0%;
+  --consonant-body-fw: 400;
+
+  /* Body type XXS */
+  --consonant-body-xxs-size: 12px;
+  --consonant-body-xxs-lh: 150%;
+  --consonant-body-xxs-ls: 0%;
+  --consonant-body-xxs-fw: 400;
+
+  /* Buttons/L Label */
+  --consonant-button-l-label-size: 19px;
+  --consonant-button-l-label-lh: 24px;
+  --consonant-button-l-label-ls: 0%;
+  --consonant-button-l-label-fw: 700;
+
+  /* Buttons/L */
+  --consonant-button-l-padding: 12px 24px 14px;
+
+  /* Verb specific variables */
+  --verb-widget-image-width: 120px;
+  --verb-widget-min-height: 528px;
+  --verb-widget-padding: var(--consonant-spacing-m) var(--consonant-spacing-xs);
   --verb-wrapper-padding-y: var(--consonant-spacing-s);
   --verb-wrapper-padding-x: var(--consonant-spacing-s);
-  --verb-wrapper-min-height: auto;
+  --verb-wrapper-border-width: 3px;
+  --verb-info-icon-margin: 8px 10px 0 4px;
+  --verb-info-icon-size-width: 18px;
+  --verb-info-icon-size-height: 18px;
+  --verb-cta-margin-bottom: var(--consonant-spacing-s);
+
+  /* Spacing */
+   --consonant-spacing-xxs: 8px;
+   --consonant-spacing-xs: 16px;
+   --consonant-spacing-s: 24px;
+   --consonant-spacing-m: 32px;
+   --consonant-spacing-l: 40px;
+   --consonant-spacing-xl: 56px;
+   --consonant-spacing-xxl: 80px;
+   --consonant-spacing-xxxl: 104px;
+
+  /* Radius */
+  --consonant-radius-s: 10px;
+  --consonant-radius-m: 12px;
+  --consonant-radius-l: 16px;
+  --consonant-radius-xl: 20px;
+
+  /* Tablets */
+  --consonant-tablet-width: 768px;
+  --consonant-tablet-width-max: 1024px;
+
+  /* Verb Widget */
+  --gnav-height: 115px;
+  --footer-height: calc(72px + var(--consonant-spacing-s));
+  --header-height: calc(var(--gnav-height) + var(--footer-height));
+  --border-total-height: calc(var(--verb-wrapper-border-width) * 2);
+  --padding-total-height: calc(var(--consonant-spacing-m) + (var(--consonant-spacing-s) * 2));
+  --total-height: calc(100vh - (var(--header-height) + var(--padding-total-height) + var(--border-total-height)));
+  --verb-wrapper-min-height: calc(100vh - (var(--header-height) + var(--padding-total-height) + var(--border-total-height)));
   --verb-wrapper-width: 1008px;
   --verb-wrapper-max-width: calc(var(--verb-wrapper-width) - ((var(--verb-wrapper-padding-x) * 2) + var(--verb-wrapper-border-width) * 2));
 
-  --verb-widget-padding: var(--consonant-spacing-m) var(--consonant-spacing-xs);
-  --verb-widget-min-height: 528px;
-  --verb-widget-image-width: 120px;
-
-  --consonant-heading-xxl-size: 36px;
-  --consonant-heading-xxl-fw: 700;
-  --consonant-body-m-size: 18px;
-  --consonant-body-xxs-size: 12px;
-  --consonant-button-l-label-size: 19px;
-
-  --gnav-height: 115px;
-  --footer-height: calc(72px + var(--consonant-spacing-s));
-
-  @media (min-width: 835px) {
+  @media screen and (min-width: 835px) {
     --verb-widget-min-height: 360px;
     --verb-wrapper-min-height: auto;
     --verb-widget-padding: 32px 40px;
     --verb-widget-image-width: 160px;
     --verb-wrapper-padding-y: 40px;
     --verb-wrapper-padding-x: 40px;
+    --verb-cta-margin-bottom: 0;
+    --verb-info-icon-margin: 0 0 0 var(--consonant-spacing-xs);
+    --consonant-logo-m-img-width: 41.5px;
+    --consonant-logo-m-img-height: 40px;
   }
 
-  @media (min-width: 1200px) {
+  @media screen and (min-width: 1200px) {
+    --verb-widget-min-height: auto;
     --verb-widget-padding: 32px 96px;
     --verb-wrapper-min-height: 475px;
     --verb-widget-image-width: 200px;
     --verb-wrapper-padding-x: 96px;
+    --consonant-logo-m-img-width: 58px;
+    --consonant-logo-m-img-height: 56px;
+    --consonant-logo-m-size: 38px;
+    --consonant-logo-m-lh: 125%;
+    --consonant-logo-m-ls: -1%;
+    --consonant-logo-m-fw: 700;
+
+    /* Heading type XXL */
     --consonant-heading-xxl-size: 44px;
   }
 
-  @media (min-width: 1392px) {
+  @media screen and (min-width: 1392px) {
     --verb-wrapper-width: 1200px;
   }
 }
 
-/* ── Block shell ────────────────────────────────────────────────────────────── */
-
 .verb-widget-client-upload {
+  color: transparent;
   background-color: #fff;
-  background-image: linear-gradient(180deg, #eb1000 0%, #f79b94 46%, #fff 78%);
+  background-image: linear-gradient(180deg, #EB1000 0%, #F79B94 46%, #FFF 78%);
   padding: var(--verb-widget-padding);
   min-height: var(--verb-widget-min-height);
-  color: transparent;
 }
 
 .verb-widget-client-upload.ready {
   color: initial;
 }
 
-/* ── Drop zone wrapper ──────────────────────────────────────────────────────── */
+.verb-legal-wrapper {
+  align-items: flex-start;
+  display: flex;
+  flex-flow: column;
+}
+
+.verb-legal {
+  display: inline-block;
+  color: var(--consonant-color-gray-700);
+  margin: 0;
+  font-size: var(--consonant-body-xxs-size);
+  line-height: var(--consonant-body-xxs-lh);
+  letter-spacing: var(--consonant-body-xxs-ls);
+}
+
+.verb-legal-two {
+  margin-top: 0;
+}
+
+.acrobat-icon {
+  display: inline-flex;
+  width: var(--consonant-logo-m-img-width);
+  height: var(--consonant-logo-m-img-height);
+}
+
+.verb-image {
+  width: var(--verb-widget-image-width);
+}
+
+.verb-image svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.security-icon {
+  display: flex;
+  padding: 8.5px 11px;
+}
+
+.info-icon {
+  display: flex;
+  margin: var(--verb-info-icon-margin);
+}
+
+.info-icon svg {
+  display: block;
+  width: var(--verb-info-icon-size-width);
+  height: var(--verb-info-icon-size-height);
+}
+
+.verb-footer {
+  align-items: center;
+  display: flex;
+  flex-flow: row;
+  justify-content: center;
+  margin-top: var(--consonant-spacing-s);
+}
+
+.verb-footer a {
+  text-decoration: underline;
+  color: var(--consonant-link-color);
+}
+
+.verb-footer a:hover {
+  color: var(--consonant-link-color-hover);
+}
 
 .verb-wrapper {
   max-width: var(--verb-wrapper-max-width);
@@ -83,21 +212,21 @@
   border: var(--verb-wrapper-border-width) dashed var(--consonant-color-gray-300);
   border-radius: var(--consonant-radius-xl);
   min-height: var(--verb-wrapper-min-height);
+  justify-content: flex-start;
   background-color: #fff;
   cursor: pointer;
-  margin-inline: auto;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .verb-wrapper:hover {
-  border-color: #909090;
+  border: 3px dashed #909090;
 }
 
 .verb-wrapper.dragging {
   background-color: #ecf5ff;
-  border: 3px solid #0265dc;
+  border: 3px #0265dc solid;
 }
-
-/* ── Layout ─────────────────────────────────────────────────────────────────── */
 
 .verb-row {
   width: 100%;
@@ -116,97 +245,53 @@
   justify-content: center;
 }
 
-/* ── Header (Acrobat icon + "Adobe Acrobat") ────────────────────────────────── */
-
-.verb-header {
-  display: flex;
-  align-items: center;
-  gap: var(--consonant-spacing-xxs);
-  margin-bottom: var(--consonant-spacing-xxs);
-}
-
-.acrobat-icon {
-  display: inline-flex;
-  width: 42px;
-  height: 40px;
-}
-
-.acrobat-icon svg,
-.icon-verb {
-  width: 100%;
-  height: 100%;
-}
-
-.verb-title {
-  font-family: var(--consonant-font-family);
-  font-size: var(--consonant-body-m-size);
-  font-weight: 700;
-  color: var(--consonant-color);
-}
-
-/* ── Heading ────────────────────────────────────────────────────────────────── */
-
-.verb-heading {
-  font-family: var(--consonant-font-family);
-  font-size: var(--consonant-heading-xxl-size);
-  font-weight: var(--consonant-heading-xxl-fw);
-  line-height: 125%;
-  color: var(--consonant-color);
-  margin: var(--consonant-spacing-xxs) 0 var(--consonant-spacing-s);
-}
-
-/* ── Body copy ──────────────────────────────────────────────────────────────── */
-
 .verb-copy {
-  font-family: var(--consonant-font-family);
   font-size: var(--consonant-body-m-size);
-  line-height: 150%;
-  color: var(--consonant-color);
-  margin: 0 0 var(--consonant-spacing-s);
+  line-height: var(--consonant-body-m-lh);
+  color: var(--consonant-color-gray-700);
+  margin-block-start: var(--spacing-xs);
+  margin-block-end: var(--spacing-s);
 }
-
-/* ── CTA button ─────────────────────────────────────────────────────────────── */
 
 .verb-cta {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  padding: 12px 24px 14px;
-  background: #1473e6;
-  color: #fff;
-  border: none;
-  border-radius: 24px;
-  font-family: var(--consonant-font-family);
+  font-family: var(--font-family);
   font-size: var(--consonant-button-l-label-size);
-  font-weight: 700;
+  background-color: var(--consonant-button-accent-action-bg);
+  color: var(--consonant-button-accent-action-text);
+  line-height: var(--consonant-button-l-label-lh);
+  letter-spacing: var(--consonant-button-l-label-ls);
+  font-weight: var(--consonant-button-l-label-fw);
+  border: none;
+  text-align: left;
   cursor: pointer;
-  margin-bottom: var(--consonant-spacing-s);
-  transition: background 0.15s;
+  border-radius: var(--consonant-radius-s);
+  padding: var(--consonant-button-l-padding);
+  white-space: pre-wrap;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-width: 130px;
+  margin-bottom: var(--verb-cta-margin-bottom);
+}
+
+.verb-cta .upload-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: var(--consonant-spacing-xxs);
+  width: 24px;
+  height: 24px;
+}
+
+html[dir="rtl"] .verb-cta .upload-icon {
+  margin-right: 0;
+  margin-left: 8px;
 }
 
 .verb-cta:hover {
-  background: #0d66d0;
-}
-
-.verb-cta:disabled {
-  background: #747474;
-  cursor: default;
-}
-
-.upload-icon {
-  width: 22px;
-  height: 22px;
-  flex-shrink: 0;
-}
-
-.hide {
-  display: none !important;
-}
-
-/* ── Error state ────────────────────────────────────────────────────────────── */
-
-.error.hide {
-  display: none;
+  text-decoration: none;
+  color: #fff;
+  background-color: var(--consonant-button-accent-action-bg-hover);
 }
 
 .verb-error {
@@ -272,7 +357,186 @@
   height: 18px;
 }
 
-/* ── Progress bar ──────────────────────────────────────────────────────────── */
+.verb-heading {
+  color: var(--consonant-color);
+  font-size: var(--consonant-heading-xxl-size);
+  line-height: var(--consonant-heading-xxl-lh);
+  margin-block-start: var(--spacing-s);
+  margin-block-end: var(--spacing-xs);
+  word-break: break-word;
+}
+
+.verb-header {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin-block-end: var(--spacing-s);
+}
+
+.verb-title {
+  font-size: var(--consonant-logo-m-size);
+  line-height: var(--consonant-logo-m-lh);
+  letter-spacing: var(--consonant-logo-m-ls);
+  font-weight: var(--consonant-logo-m-fw);
+  color: var(--consonant-logo-color);
+  margin-inline-start: 15px;
+}
+
+.error.hide {
+  display: none;
+}
+
+.hide {
+  display: none !important;
+}
+
+@media screen and (min-width: 768px) {
+  .verb-container {
+    align-items: center;
+    display: flex;
+    flex: 1 1 50%;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width: 768px) {
+  .verb-wrapper {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: row;
+    justify-content: center;
+  }
+}
+
+@media screen and (max-width: 767px) {
+  .verb-row {
+    flex-direction: column;
+    align-items: start;
+  }
+
+  .verb-col.right {
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+  }
+
+  .verb-footer {
+    align-items: start;
+  }
+}
+
+.verb-widget-client-upload .milo-tooltip {
+  position: relative;
+  text-decoration: none;
+  border-bottom: none;
+  min-width: 24px;
+  display: inline-flex;
+  min-height: 24px;
+  align-items: center;
+  justify-content: center;
+}
+
+.verb-widget-client-upload .milo-tooltip::before {
+  content: attr(data-tooltip);
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  left: 100%;
+  margin-left: 7px;
+  max-width: 140px;
+  padding: 10px;
+  border-radius: 5px;
+  background: #0469E3;
+  color: #fff;
+  text-align: left;
+  display: none;
+  z-index: 8;
+  font-size: 12px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 16px;
+  width: max-content;
+}
+
+.verb-widget-client-upload .milo-tooltip::after {
+  content: "";
+  position: absolute;
+  left: 100%;
+  margin-left: -8px;
+  top: 50%;
+  transform: translateY(-50%);
+  border: 8px solid #0469E3;
+  border-color: transparent #0469E3 transparent transparent;
+  display: none;
+  z-index: 8;
+}
+
+.verb-widget-client-upload .milo-tooltip.top::before {
+  left: 50%;
+  transform: translateX(-50%) translateY(-100%);
+  top: -6px;
+  margin-bottom: 15px;
+  margin-left: 0;
+}
+
+.verb-widget-client-upload .milo-tooltip.top::after {
+  left: 50%;
+  top: 2px;
+  transform: translateX(-50%) translateY(-50%);
+  border: 8px solid #0469E3;
+  border-color: #0469E3 transparent transparent;
+  margin-left: 0;
+}
+
+.verb-widget-client-upload .milo-tooltip:hover::before,
+.verb-widget-client-upload .milo-tooltip:focus::before,
+.verb-widget-client-upload .milo-tooltip:active::before {
+  display: block;
+}
+
+.verb-widget-client-upload .milo-tooltip:hover::after,
+.verb-widget-client-upload .milo-tooltip:focus::after,
+.verb-widget-client-upload .milo-tooltip:active::after {
+  display: block;
+}
+
+@media screen and (max-width: 1199px) {
+  .verb-widget-client-upload .mobile.milo-tooltip.top::before {
+    left: 0;
+    right: auto;
+    transform: translateX(0) translateY(-100%);
+    max-width: 200px;
+  }
+
+  .verb-widget-client-upload .mobile.milo-tooltip.top::after {
+    left: 4px;
+    right: auto;
+    transform: translateX(0) translateY(-50%);
+  }
+
+  .verb-widget-client-upload .tablet.milo-tooltip.top::before,
+  .verb-widget-client-upload .milo-tooltip.top::before {
+    left: auto;
+    right: 0;
+    transform: translateX(0) translateY(-100%);
+    max-width: 200px;
+  }
+
+  .verb-widget-client-upload .tablet.milo-tooltip.top::after,
+  .verb-widget-client-upload .milo-tooltip.top::after {
+    left: auto;
+    right: 4px;
+    transform: translateX(0) translateY(-50%);
+  }
+}
+
+@media screen and (min-width: 1200px) {
+  .verb-widget-client-upload .milo-tooltip.top::before {
+    max-width: 180px;
+  }
+}
+
+/* ── Progress bar (client-upload only) ─────────────────────────────────────── */
 
 .upload-progress {
   display: flex;
@@ -282,7 +546,6 @@
 }
 
 .upload-progress-label {
-  font-family: var(--consonant-font-family);
   font-size: 14px;
   color: var(--consonant-color-gray-700);
   white-space: nowrap;
@@ -308,72 +571,155 @@
   transition: width 0.2s ease;
 }
 
-.upload-cancel-btn {
-  align-self: flex-start;
-  background: none;
-  border: 1px solid var(--consonant-color-gray-300);
-  border-radius: 16px;
-  padding: 4px 14px;
-  font-family: var(--consonant-font-family);
-  font-size: 14px;
-  color: var(--consonant-color-gray-700);
-  cursor: pointer;
-  margin-top: 2px;
+/* ── Signed-in / upsell states ─────────────────────────────────────────────── */
+
+.verb-widget-client-upload.signed-in .verb-footer {
+  display: none;
 }
 
-.upload-cancel-btn:hover {
-  border-color: #909090;
+.verb-widget-client-upload.signed-in .verb-upsell-active {
+  display: none;
 }
 
-/* ── Image column ────────────────────────────────────────────────────────────── */
-
-.verb-image {
-  width: var(--verb-widget-image-width);
+.verb-widget-client-upload.upsell .verb-footer {
+  display: none;
 }
 
-.verb-image svg {
-  display: block;
-  width: 100%;
-  height: 100%;
+.verb-widget-client-upload.upsell #drop-zone {
+  display: none;
 }
 
-/* ── Footer ─────────────────────────────────────────────────────────────────── */
-
-.verb-footer {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-top: var(--consonant-spacing-s);
+.verb-wrapper.verb-upsell-active {
+  cursor: default;
+  border: 3px solid var(--consonant-color-gray-300);
 }
 
-.security-icon {
-  display: flex;
-  padding: 8.5px 11px;
+.verb-wrapper.verb-upsell-active:hover {
+  border: 3px solid var(--consonant-color-gray-300);
 }
 
-.verb-legal-wrapper {
+.verb-upsell {
+  color: #222;
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  width: 100%;
+  height: 100%;
+  position: static;
+  justify-content: normal;
+  align-items: normal;
 }
 
-.verb-legal {
-  display: inline-block;
-  color: var(--consonant-color-gray-700);
-  margin: 0;
-  font-size: var(--consonant-body-xxs-size);
-  line-height: 150%;
+.verb-upsell-heading {
+  display: inline;
+  font-size: 32px;
+  font-weight: 700;
+  line-height: 40px;
+  margin-bottom: 8px;
 }
 
-.verb-legal-two {
-  margin-top: 0;
+.verb-upsell-heading + .verb-upsell-heading {
+  margin-left: 5px;
 }
 
-.verb-legal-url {
-  text-decoration: underline;
-  color: var(--consonant-link-color);
+.verb-upsell-heading-nopayment {
+  font-weight: 400 !important;
 }
 
-.verb-legal-url:hover {
-  color: var(--consonant-link-color-hover);
+.verb-upsell-bullets-heading {
+  margin-bottom: -4px;
+  margin-top: 24px;
+  padding-left: 0;
+}
+
+.verb-upsell-bullets {
+  margin-top: 8px;
+  padding: 0 0 0 15px;
+}
+
+.verb-upsell-bullets li {
+  list-style: none;
+  position: relative;
+  padding-left: 0;
+  margin-bottom: 8px;
+}
+
+.verb-upsell-bullets li::before {
+  content: "•";
+  position: absolute;
+  left: -12px;
+}
+
+.verb-upsell-column {
+  flex: 1;
+  padding: 0 12px;
+}
+
+.verb-upsell-social-container {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 20px;
+  margin: 0 20px;
+  background-color: #fdfdfd;
+  border: 1px solid #e6e6e6;
+  border-radius: 10px;
+}
+
+.verb-mobile-cta {
+  display: inline-flex;
+  padding: 12px 24px;
+  border-radius: 100px;
+  background: #1473e6;
+  color: white;
+  font-weight: 700;
+  justify-content: center;
+  align-items: center;
+  font-size: 19px;
+  line-height: 29px;
+  text-decoration: none;
+  white-space: pre-wrap;
+  text-align: center;
+  margin-bottom: var(--consonant-spacing-s);
+}
+
+.verb-mobile-cta:hover,
+.verb-mobile-cta:active {
+  background-color: #0054b6;
+  color: #fff;
+  text-decoration: none;
+}
+
+@media screen and (max-width: 767px) {
+  .verb-upsell {
+    width: 100%;
+    height: auto;
+  }
+
+  .verb-upsell-heading {
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    white-space: normal;
+    max-width: 100%;
+  }
+
+  .verb-upsell-bullets-heading {
+    margin-bottom: -4px;
+    margin-top: 16px;
+  }
+
+  .verb-upsell-bullets {
+    margin-top: 4px;
+  }
+
+  .verb-upsell-bullets li {
+    margin-bottom: 0;
+  }
+
+  .verb-upsell-social-container {
+    width: 100%;
+    border: none;
+    background-color: transparent;
+    padding: 0;
+  }
 }

--- a/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.css
+++ b/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.css
@@ -542,41 +542,6 @@ html[dir="rtl"] .verb-cta .upload-icon {
   }
 }
 
-/* ── Progress bar (client-upload only) ─────────────────────────────────────── */
-
-.upload-progress {
-  display: flex;
-  flex-direction: column;
-  gap: var(--consonant-spacing-xxs);
-  margin-bottom: var(--consonant-spacing-s);
-}
-
-.upload-progress-label {
-  font-size: 14px;
-  color: var(--consonant-color-gray-700);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 340px;
-}
-
-.upload-progress-bar {
-  width: 100%;
-  max-width: 340px;
-  height: 6px;
-  background: var(--consonant-color-gray-300);
-  border-radius: 3px;
-  overflow: hidden;
-}
-
-.upload-progress-fill {
-  height: 100%;
-  width: 0%;
-  background: #1473e6;
-  border-radius: 3px;
-  transition: width 0.2s ease;
-}
-
 /* ── Signed-in / upsell states ─────────────────────────────────────────────── */
 
 .verb-widget-client-upload.signed-in .verb-footer {

--- a/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.css
+++ b/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.css
@@ -294,6 +294,12 @@ html[dir="rtl"] .verb-cta .upload-icon {
   background-color: var(--consonant-button-accent-action-bg-hover);
 }
 
+.verb-cta:disabled {
+  opacity: 0.6;
+  cursor: default;
+  pointer-events: none;
+}
+
 .verb-error {
   cursor: default;
   background: #D31510;

--- a/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.css
+++ b/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.css
@@ -205,46 +205,74 @@
 
 /* ── Error state ────────────────────────────────────────────────────────────── */
 
-.error {
-  display: flex;
-  align-items: flex-start;
-  gap: 8px;
-  background: #fff4f4;
-  border: 1px solid #eb1000;
-  border-radius: 8px;
-  padding: var(--consonant-spacing-xxs) var(--consonant-spacing-xs);
-  margin-bottom: var(--consonant-spacing-s);
-}
-
 .error.hide {
   display: none;
 }
 
-.verb-errorText {
-  flex: 1;
-  font-family: var(--consonant-font-family);
+.verb-error {
+  cursor: default;
+  background: #D31510;
+  max-width: 435px;
+  color: white;
+  position: absolute;
+  top: 90px;
+  transform: translate(-50%, -50%);
+  left: 50%;
   font-size: 14px;
-  color: #eb1000;
+  font-weight: 400;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 8px;
+}
+
+.close-icon {
+  position: relative;
+}
+
+.verb-errorText {
+  border-right: 1px solid rgb(255 255 255 / 20%);
+  padding: 0;
   margin: 0;
+  margin-right: 8px;
+  padding-right: 16px;
+  max-width: 324px;
+  margin-left: 8px;
+  min-width: 100px;
 }
 
 .verb-errorBtn {
+  align-self: self-start;
+  width: 32px;
+  height: 32px;
+  cursor: pointer;
+  display: block;
   background: none;
   border: none;
-  cursor: pointer;
-  font-size: 14px;
-  color: #eb1000;
-  padding: 0;
-  line-height: 1;
+  outline: none;
 }
 
-/* ── Progress bar ───────────────────────────────────────────────────────────── */
-/*
- * This section has no equivalent in verb-widget because Unity SDK manages
- * its own loading/progress UI inside the DC Hosted iframe.
- * In this client-side block we own the full upload lifecycle, so we build
- * our own progress indicator here.
- */
+.verb-errorIcon {
+  align-self: self-start;
+  width: 18px;
+  height: 18px;
+  margin-left: 8px;
+  margin-right: 4px;
+  margin-top: 7px;
+}
+
+.verb-errorIcon::after {
+  content: '';
+  background-image: url('/acrobat/img/icons/ui/alert.svg');
+  background-repeat: no-repeat;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+}
+
+/* ── Progress bar ──────────────────────────────────────────────────────────── */
 
 .upload-progress {
   display: flex;

--- a/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.js
+++ b/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.js
@@ -627,7 +627,7 @@ export default async function init(element) {
       setProgress(1, 'Done');
 
       const redirectBase = window.mph?.['verb-widget-client-upload-redirect']
-        || 'https://www.stage.adobe.com/acrobat/online.html';
+        || 'https://mwpw-197746--da-dc--adobecom.aem.page/acrobat/online';
       const [baseUrl, queryString] = redirectBase.split('?');
       const redirectUrl = `${baseUrl}?UTS_Uploaded=${uploadTimestamp}&redirectTime=${Date.now()}&fileId=${id}${queryString ? `&${queryString}` : ''}`;
       handleAnalyticsEvent('job:redirect-success', { ...filesData, redirectUrl }, false);

--- a/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.js
+++ b/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.js
@@ -624,7 +624,7 @@ export default async function init(element) {
       const redirectBase = window.mph?.['verb-widget-client-upload-redirect']
         || 'https://mwpw-197746--da-dc--adobecom.aem.live/acrobat/online';
       const [baseUrl, queryString] = redirectBase.split('?');
-      const redirectUrl = `${baseUrl}?UTS_Uploaded=${uploadTimestamp}&redirectTime=${Date.now()}&fileId=${id}${queryString ? `&${queryString}` : ''}`;
+      const redirectUrl = `${baseUrl}?clientConvert=true&UTS_Uploaded=${uploadTimestamp}&redirectTime=${Date.now()}&fileId=${id}${queryString ? `&${queryString}` : ''}`;
       handleAnalyticsEvent('job:redirect-success', { ...filesData, redirectUrl }, false);
       window.location.href = redirectUrl;
     } catch (err) {

--- a/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.js
+++ b/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.js
@@ -1,3 +1,4 @@
+/* eslint-disable compat/compat */
 import { setLibs, getEnv, isOldBrowser } from '../../scripts/utils.js';
 
 const miloLibs = setLibs('/libs');
@@ -14,9 +15,7 @@ const EOLBrowserPage = 'https://acrobat.adobe.com/home/index-browser-eol.html';
 const MB25 = 26214400;
 const ACCEPTED_FILES = ['.jpg', '.jpeg', '.png'];
 
-const LIMITS = {
-  'image-to-pdf': { maxFileSize: MB25, acceptedFiles: ACCEPTED_FILES, multipleFiles: false },
-};
+const LIMITS = { 'image-to-pdf': { maxFileSize: MB25, acceptedFiles: ACCEPTED_FILES, multipleFiles: false } };
 
 const DC_ENV = ['www.adobe.com', 'sign.ing', 'edit.ing'].includes(window.location.hostname) ? 'prod' : 'stage';
 
@@ -250,10 +249,9 @@ async function storeEncryptedLocalFile(id, file) {
   db.close();
 }
 
-async function encryptAndStore(file, { onProgress } = {}) {
+async function encryptAndStore(file) {
   const id = crypto.randomUUID();
   await storeEncryptedLocalFile(id, file);
-  onProgress?.(1);
   return id;
 }
 
@@ -420,13 +418,6 @@ export default async function init(element) {
     ...(limits.multipleFiles && { multiple: '' }),
   });
 
-  const progressContainer = createTag('div', { class: 'upload-progress hide' });
-  const progressLabel = createTag('div', { class: 'upload-progress-label' });
-  const progressBar = createTag('div', { class: 'upload-progress-bar' });
-  const progressFill = createTag('div', { class: 'upload-progress-fill' });
-  progressBar.append(progressFill);
-  progressContainer.append(progressLabel, progressBar);
-
   const widgetImage = createTag('div', { class: 'verb-image' });
   const verbImageSvg = await createSvgElement(VERB);
   if (verbImageSvg) {
@@ -446,7 +437,10 @@ export default async function init(element) {
   });
   const securityIconSvg = await createSvgElement('SECURITY_ICON');
   const infoIconSvg = await createSvgElement('INFO_ICON');
-  if (securityIconSvg) { iconSecurity.appendChild(securityIconSvg); infoIcon.appendChild(infoIconSvg); }
+  if (securityIconSvg) {
+    iconSecurity.appendChild(securityIconSvg);
+    infoIcon.appendChild(infoIconSvg);
+  }
   const legalWrapper = createTag('div', { class: 'verb-legal-wrapper' });
   const legal = createTag('p', { class: 'verb-legal' }, `${window.mph?.['verb-widget-legal'] ?? ''} `);
   const legalTwo = createTag('p', { class: 'verb-legal verb-legal-two' });
@@ -474,7 +468,14 @@ export default async function init(element) {
   }
 
   errorState.append(errorIcon, errorText, closeErrorBtn);
-  widgetLeft.append(widgetHeader, widgetHeading, widgetCopy, errorState, ctaButton, fileInput, progressContainer);
+  widgetLeft.append(
+    widgetHeader,
+    widgetHeading,
+    widgetCopy,
+    errorState,
+    ctaButton,
+    fileInput,
+  );
   widgetRight.append(widgetImage);
   widgetRow.append(widgetLeft, widgetRight);
   widgetContainer.append(widgetRow);
@@ -515,19 +516,6 @@ export default async function init(element) {
   await checkSignedInUser();
   window.addEventListener('IMS:Ready', checkSignedInUser);
 
-  const setProgress = (ratio, label = '') => {
-    const pct = Math.round(ratio * 100);
-    progressFill.style.width = `${pct}%`;
-    progressLabel.textContent = label || `${pct}%`;
-    progressFill.setAttribute('aria-valuenow', pct);
-  };
-
-  const hideProgress = () => {
-    progressContainer.classList.add('hide');
-    ctaButton.classList.remove('hide');
-    setProgress(0);
-  };
-
   const showError = (message) => {
     errorText.textContent = message;
     errorState.classList.remove('hide');
@@ -554,11 +542,6 @@ export default async function init(element) {
     const uploaded = parseInt(document.cookie.match(/UTS_Uploaded=([^;]*)/)?.[1], 10);
     if (Number.isNaN(uploading) || Number.isNaN(uploaded)) return 'N/A';
     return ((uploaded - uploading) / 1000).toFixed(1);
-  }
-
-  function getFileType(files) {
-    const types = [...new Set(files.map((f) => f.type))];
-    return types.length > 1 ? 'mixed' : types[0] || '';
   }
 
   const errorAnalyticsMap = {
@@ -655,7 +638,10 @@ export default async function init(element) {
     exitFlag = false;
     handleAnalyticsEvent('choose-file:open', { userAttempts }, true);
     const validation = validateFiles(files, VERB);
-    if (!validation.valid) { dispatchError(validation.code, validation.message, { userAttempts }); return; }
+    if (!validation.valid) {
+      dispatchError(validation.code, validation.message, { userAttempts });
+      return;
+    }
     startUpload(Array.from(files));
   });
 
@@ -681,7 +667,10 @@ export default async function init(element) {
       handleAnalyticsEvent(evt, { userAttempts }, true);
     });
     const validation = validateFiles(files, VERB);
-    if (!validation.valid) { dispatchError(validation.code, validation.message, { userAttempts }); return; }
+    if (!validation.valid) {
+      dispatchError(validation.code, validation.message, { userAttempts });
+      return;
+    }
     startUpload(Array.from(files));
   });
 

--- a/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.js
+++ b/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.js
@@ -622,8 +622,8 @@ export default async function init(element) {
       handleAnalyticsEvent('job:uploaded', uploadedMetadata, false);
 
       const redirectBase = DC_ENV === 'prod'
-        ? 'https://www.adobe.com/acrobat-online/image-to-pdf.html'
-        : 'https://www.stage.adobe.com/acrobat-online/image-to-pdf.html';
+        ? 'https://www.adobe.com/acrobat-online/jpg-to-pdf.html'
+        : 'https://www.stage.adobe.com/acrobat-online/jpg-to-pdf.html';
       const [baseUrl, queryString] = redirectBase.split('?');
       const redirectUrl = `${baseUrl}?clientConvert=true&UTS_Uploaded=${uploadTimestamp}&redirectTime=${Date.now()}&fileId=${id}${queryString ? `&${queryString}` : ''}&force_meteriq=true`;
       handleAnalyticsEvent('job:redirect-success', { ...filesData, redirectUrl }, false);

--- a/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.js
+++ b/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.js
@@ -210,7 +210,7 @@ function validateFiles(files, verb) {
   const mph = window.mph ?? {};
 
   if (!limits || !files.length) {
-    return { valid: false, code: 'error_generic', message: mph['verb-widget-error-generic'] || 'No files selected.' };
+    return { valid: false, code: 'error_generic', message: mph['verb-widget-error-generic'] || 'Unable to process the request.' };
   }
 
   if (!limits.multipleFiles && !limits.maxNumFiles && files.length > 1) {
@@ -226,7 +226,7 @@ function validateFiles(files, verb) {
     return {
       valid: false,
       code: 'error_max_num_files',
-      message: mph['verb-widget-error-max-num-files'] || `Maximum ${maxFiles} file${maxFiles === 1 ? '' : 's'} allowed. You selected ${files.length}.`,
+      message: mph['verb-widget-error-max-num-files'] || 'Too many files selected.',
     };
   }
 
@@ -236,25 +236,25 @@ function validateFiles(files, verb) {
     return {
       valid: false,
       code: 'error_duplicate_asset',
-      message: mph['verb-widget-error-duplicate-asset'] || `Duplicate file: "${firstDuplicate}". Each file must have a unique name.`,
+      message: mph['verb-widget-error-duplicate-asset'] || 'Duplicate detected. Please rename file before uploading again.',
     };
   }
 
+  const multi = files.length > 1;
   for (const file of files) {
     if (file.size === 0) {
       return {
         valid: false,
         code: 'error_empty_file',
-        message: mph['verb-widget-error-empty-file'] || `"${file.name}" is empty.`,
+        message: mph['verb-widget-error-empty-file'] || (multi ? 'These files are empty.' : 'This file is empty.'),
       };
     }
 
     if (file.size > limits.maxFileSize) {
-      const mb = (limits.maxFileSize / 1024 / 1024).toFixed(0);
       return {
         valid: false,
         code: 'error_file_too_large',
-        message: mph['verb-widget-error-file-too-large'] || `"${file.name}" exceeds the ${mb} MB size limit.`,
+        message: mph['verb-widget-error-file-too-large'] || (multi ? 'These files are either too large or too complex to export.' : 'This file is either too large or too complex to export.'),
       };
     }
 
@@ -263,7 +263,7 @@ function validateFiles(files, verb) {
       return {
         valid: false,
         code: 'error_unsupported_type',
-        message: mph['verb-widget-error-unsupported-type'] || `"${file.name}" is not a supported file type.`,
+        message: mph['verb-widget-error-unsupported-type'] || (multi ? 'These files are in a format not supported for conversion to PDF.' : 'This file is in a format not supported for conversion to PDF.'),
       };
     }
 
@@ -272,7 +272,7 @@ function validateFiles(files, verb) {
       return {
         valid: false,
         code: 'error_unsupported_type',
-        message: mph['verb-widget-error-unsupported-type'] || `"${file.name}" doesn't appear to be a valid ${ext.slice(1).toUpperCase()} file.`,
+        message: mph['verb-widget-error-unsupported-type'] || (multi ? 'These files are in a format not supported for conversion to PDF.' : 'This file is in a format not supported for conversion to PDF.'),
       };
     }
   }

--- a/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.js
+++ b/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.js
@@ -1,0 +1,614 @@
+import { setLibs, getEnv, isOldBrowser } from '../../scripts/utils.js';
+
+const miloLibs = setLibs('/libs');
+
+let createTag;
+let getConfig;
+
+const EOLBrowserPage = 'https://acrobat.adobe.com/home/index-browser-eol.html';
+
+const MB100 = 104857600;
+const CHUNK_SIZE = 5 * 1024 * 1024;
+const CHUNK_THRESHOLD = 50 * 1024 * 1024;
+const ALL_FILES = ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.bmp', '.gif', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'];
+
+const LIMITS = {
+  'image-to-pdf': { maxFileSize: MB100, acceptedFiles: ALL_FILES, multipleFiles: true },
+};
+
+const MIME_TYPES = {
+  '.pdf': ['application/pdf'],
+  '.jpg': ['image/jpeg'],
+  '.jpeg': ['image/jpeg'],
+  '.png': ['image/png'],
+  '.gif': ['image/gif'],
+  '.bmp': ['image/bmp'],
+  '.tif': ['image/tiff'],
+  '.tiff': ['image/tiff'],
+  '.doc': ['application/msword'],
+  '.docx': ['application/vnd.openxmlformats-officedocument.wordprocessingml.document'],
+  '.ppt': ['application/vnd.ms-powerpoint'],
+  '.pptx': ['application/vnd.openxmlformats-officedocument.presentationml.presentation'],
+  '.xls': ['application/vnd.ms-excel'],
+  '.xlsx': ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+  '.txt': ['text/plain'],
+  '.rtf': ['application/rtf', 'text/rtf'],
+  '.xml': ['text/xml', 'application/xml'],
+};
+
+const ICONS = {
+  WIDGET_ICON: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0.3 24 23.4"><g id="Surfaces"><path fill="#b30b00" d="M4.25.3h15.5A4.24643,4.24643,0,0,1,24,4.55v14.9a4.24643,4.24643,0,0,1-4.25,4.25H4.25A4.24643,4.24643,0,0,1,0,19.45V4.55A4.24643,4.24643,0,0,1,4.25.3Z"/></g><g id="Outlined_Mnemonics_Logos" data-name="Outlined Mnemonics Logos"><path id="_256" data-name=" 256" fill="#fff" d="M19.3,13.85a1.78946,1.78946,0,0,0-.44031-.33547,2.83828,2.83828,0,0,0-.59969-.24078,4.79788,4.79788,0,0,0-.75719-.14516A7.94332,7.94332,0,0,0,16.59,13.08q-.27375.00375-.54891.017-.27492.01337-.54984.03672-.2747.02345-.548.05734-.273.034-.54328.07891-.1725-.16875-.33891-.345-.16617-.17625-.32484-.36-.15844-.18375-.308-.375-.1493-.19125-.28828-.39-.10875-.14625-.212-.29625-.10337-.15-.20172-.30375-.09845-.15375-.19234-.31125-.094-.1575-.18391-.31875.17625-.55125.30766-1.04813.13148-.49688.21859-.93937.08718-.4425.13047-.83063A6.52908,6.52908,0,0,0,13.05,7.03a3.675,3.675,0,0,0-.08594-.80563A2.42373,2.42373,0,0,0,12.685,5.505a1.4927,1.4927,0,0,0-.50406-.51688A1.44959,1.44959,0,0,0,11.42,4.79a1.19728,1.19728,0,0,0-.30547.04719A1.22057,1.22057,0,0,0,10.41,5.38a2.17839,2.17839,0,0,0-.25078.82187,4.69881,4.69881,0,0,0,.007,1.08813,7.85466,7.85466,0,0,0,.25641,1.26812A10.26146,10.26146,0,0,0,10.92,9.92c-.0725.2125-.14625.42312-.222.63391s-.1536.42171-.23422.63484-.16406.42844-.25109.648S10.035,12.28,9.94,12.51q-.12375.2925-.25344.58281Q9.55672,13.383,9.42,13.67q-.13688.28688-.28156.56969Q8.99359,14.52235,8.84,14.8c-.3075.1225-.70125.28937-1.12281.49156A12.99444,12.99444,0,0,0,6.4275,15.995a6.08618,6.08618,0,0,0-1.10594.86094A1.9673,1.9673,0,0,0,4.75,17.82a1.08624,1.08624,0,0,0-.01969.29219,1.10366,1.10366,0,0,0,.05719.28281,1.13932,1.13932,0,0,0,.12844.26031A1.17812,1.17812,0,0,0,5.11,18.88a1.45543,1.45543,0,0,0,.23312.17047,1.49272,1.49272,0,0,0,.25938.12078,1.5496,1.5496,0,0,0,.27812.07016A1.60815,1.60815,0,0,0,6.17,19.26a2.26684,2.26684,0,0,0,1.16953-.36984,5.403,5.403,0,0,0,1.12172-.95391,11.55912,11.55912,0,0,0,1.02609-1.30453c.32078-.46734.61766-.95422.88266-1.42172q.225-.075.45172-.14781.22664-.07266.45453-.14219.22781-.06938.45641-.13469.22851-.06515.45734-.12531.25125-.0675.49687-.12766.24562-.06022.48563-.11359.24-.05343.47437-.10047.23438-.0471.46313-.08828a7.87389,7.87389,0,0,0,1.20266.87266,6.26924,6.26924,0,0,0,1.08359.50609,5.254,5.254,0,0,0,.913.23422A4.37649,4.37649,0,0,0,18,15.9a2.59368,2.59368,0,0,0,.65125-.07453A1.51031,1.51031,0,0,0,19.1,15.63375a1.1277,1.1277,0,0,0,.28375-.26109A1.11325,1.11325,0,0,0,19.54,15.09a1.22521,1.22521,0,0,0,.068-.32313,1.25587,1.25587,0,0,0-.12281-.63875A1.23791,1.23791,0,0,0,19.3,13.85Z"/></g></svg>',
+  UPLOAD_ICON: '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M22.0007 6.66675H18.0007C17.8238 6.66675 17.6543 6.73699 17.5292 6.86201C17.4042 6.98703 17.334 7.1566 17.334 7.33341V8.66675C17.334 8.84356 17.4042 9.01313 17.5292 9.13815C17.6543 9.26318 17.8238 9.33341 18.0007 9.33341H20.0007V20.0001H4.00065V9.33341H6.00065C6.17746 9.33341 6.34703 9.26318 6.47206 9.13815C6.59708 9.01313 6.66732 8.84356 6.66732 8.66675V7.33341C6.66732 7.1566 6.59708 6.98703 6.47206 6.86201C6.34703 6.73699 6.17746 6.66675 6.00065 6.66675H2.00065C1.82384 6.66675 1.65427 6.73699 1.52925 6.86201C1.40422 6.98703 1.33398 7.1566 1.33398 7.33341V22.0001C1.33398 22.1769 1.40422 22.3465 1.52925 22.4715C1.65427 22.5965 1.82384 22.6667 2.00065 22.6667H22.0007C22.1775 22.6667 22.347 22.5965 22.4721 22.4715C22.5971 22.3465 22.6673 22.1769 22.6673 22.0001V7.33341C22.6673 7.1566 22.5971 6.98703 22.4721 6.86201C22.347 6.73699 22.1775 6.66675 22.0007 6.66675Z" fill="white"/><path fill-rule="evenodd" clip-rule="evenodd" d="M7.1994 5.3334H10.6661V12.6667C10.6661 12.8435 10.7363 13.0131 10.8613 13.1381C10.9864 13.2632 11.1559 13.3334 11.3327 13.3334H12.6661C12.8429 13.3334 13.0124 13.2632 13.1375 13.1381C13.2625 13.0131 13.3327 12.8435 13.3327 12.6667V5.3334H16.7994C16.9409 5.3334 17.0765 5.27721 17.1765 5.17719C17.2765 5.07717 17.3327 4.94152 17.3327 4.80007C17.3339 4.67018 17.2864 4.54456 17.1994 4.44807L12.2327 0.0960672C12.1706 0.0346729 12.0868 0.000244141 11.9994 0.000244141C11.912 0.000244141 11.8282 0.0346729 11.7661 0.0960672L6.7994 4.4454C6.71182 4.54258 6.6642 4.66926 6.66607 4.80007C6.66607 4.94152 6.72226 5.07717 6.82228 5.17719C6.9223 5.27721 7.05795 5.3334 7.1994 5.3334Z" fill="white"/></svg>',
+  SECURITY_ICON: '<svg width="26" height="31" viewBox="0 0 26 31" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M13 0L25.5 4.163V14.177C25.4633 17.9427 24.2335 21.5998 21.9875 24.6226C19.7415 27.6453 16.5949 29.8781 13 31C9.4386 29.8983 6.31448 27.7033 4.07079 24.7262C1.82711 21.7491 0.577772 18.1411 0.5 14.414V14.052V4.166L13 0ZM13 1.581L2 5.246V14.051C2.00065 17.3991 3.03609 20.6651 4.96458 23.402C6.89306 26.1389 9.62033 28.2129 12.773 29.34L12.996 29.418L13.217 29.34C16.2922 28.2358 18.9645 26.2329 20.8873 23.5911C22.8101 20.9494 23.8946 17.7907 24 14.525V14.177V5.244L13 1.581Z" fill="#8E8E8E"/><path d="M19.2052 10.484C19.3352 10.3458 19.5127 10.262 19.7019 10.2494C19.8912 10.2369 20.0782 10.2965 20.2253 10.4163C20.3723 10.5361 20.4685 10.7072 20.4945 10.8951C20.5205 11.083 20.4743 11.2738 20.3652 11.429L20.2952 11.515L12.0362 20.242C11.913 20.3715 11.7476 20.4528 11.5697 20.4711C11.3919 20.4895 11.2133 20.4436 11.0662 20.342L10.9802 20.273L7.23925 16.788C7.10054 16.659 7.01577 16.4823 7.00199 16.2933C6.98821 16.1044 7.04642 15.9173 7.16494 15.7695C7.28345 15.6217 7.4535 15.5243 7.64091 15.4967C7.82832 15.4692 8.01921 15.5136 8.17525 15.621L8.26225 15.691L11.4622 18.669L19.2052 10.484Z" fill="#FA0F00"/></svg>',
+  INFO_ICON: '<svg viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg"><g opacity="0.8"><path d="M9.00078 7.0748C9.59449 7.0748 10.0758 6.59351 10.0758 5.9998C10.0758 5.4061 9.59449 4.9248 9.00078 4.9248C8.40707 4.9248 7.92578 5.4061 7.92578 5.9998C7.92578 6.59351 8.40707 7.0748 9.00078 7.0748Z" fill="#222222"/><path fill-rule="evenodd" clip-rule="evenodd" d="M10.167 12H10V8.2C10 8.14696 9.97893 8.09609 9.94142 8.05858C9.90391 8.02107 9.85304 8 9.8 8H7.833C7.833 8 7.25 8.016 7.25 8.5C7.25 8.984 7.833 9 7.833 9H8V12H7.833C7.833 12 7.25 12.016 7.25 12.5C7.25 12.984 7.833 13 7.833 13H10.167C10.167 13 10.75 12.984 10.75 12.5C10.75 12.016 10.167 12 10.167 12Z" fill="#222222"/><path fill-rule="evenodd" clip-rule="evenodd" d="M9.00078 1.0498C7.42842 1.0498 5.89137 1.51606 4.584 2.38962C3.27663 3.26318 2.25766 4.5048 1.65594 5.95747C1.05423 7.41014 0.896789 9.00862 1.20354 10.5508C1.51029 12.0929 2.26746 13.5095 3.37929 14.6213C4.49111 15.7331 5.90767 16.4903 7.44982 16.797C8.99197 17.1038 10.5904 16.9464 12.0431 16.3446C13.4958 15.7429 14.7374 14.724 15.611 13.4166C16.4845 12.1092 16.9508 10.5722 16.9508 8.9998C16.9508 6.89133 16.1132 4.86922 14.6223 3.37831C13.1314 1.88739 11.1093 1.0498 9.00078 1.0498ZM9.00078 15.9558C7.62502 15.9558 6.28015 15.5478 5.13624 14.7835C3.99233 14.0192 3.10076 12.9328 2.57428 11.6618C2.0478 10.3907 1.91004 8.99209 2.17844 7.64276C2.44684 6.29342 3.10934 5.05398 4.08215 4.08117C5.05496 3.10836 6.2944 2.44586 7.64374 2.17746C8.99307 1.90906 10.3917 2.04682 11.6627 2.5733C12.9338 3.09978 14.0202 3.99135 14.7845 5.13526C15.5488 6.27917 15.9568 7.62404 15.9568 8.9998C15.9568 10.8447 15.2239 12.6139 13.9194 13.9184C12.6149 15.2229 10.8456 15.9558 9.00078 15.9558Z" fill="#222222"/></g></svg>',
+  CLOSE_ICON: '<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg"><g clip-path="url(#clip0_15746_2423)"><g clip-path="url(#clip1_15746_2423)"><path fill-rule="evenodd" clip-rule="evenodd" d="M17.2381 15.9994L19.6944 13.5434C19.8586 13.3793 19.9509 13.1566 19.9509 12.9245C19.951 12.6923 19.8588 12.4696 19.6946 12.3054C19.5305 12.1412 19.3078 12.0489 19.0757 12.0488C18.8435 12.0488 18.6208 12.141 18.4566 12.3051L16.0002 14.7615L13.5435 12.3051C13.3793 12.141 13.1566 12.0489 12.9245 12.049C12.6923 12.0491 12.4697 12.1414 12.3057 12.3056C12.1416 12.4698 12.0495 12.6925 12.0496 12.9246C12.0497 13.1568 12.142 13.3794 12.3062 13.5434L14.7622 15.9994L12.3062 18.4555C12.1427 18.6197 12.051 18.8421 12.0512 19.0738C12.0515 19.3055 12.1436 19.5277 12.3074 19.6916C12.4711 19.8556 12.6933 19.9478 12.925 19.9482C13.1567 19.9486 13.3791 19.8571 13.5435 19.6938L16.0002 17.2374L18.4566 19.6938C18.6208 19.8579 18.8435 19.9501 19.0756 19.9501C19.3078 19.95 19.5305 19.8577 19.6946 19.6935C19.8588 19.5293 19.9509 19.3066 19.9509 19.0745C19.9509 18.8423 19.8586 18.6196 19.6944 18.4555L17.2381 15.9994Z" fill="white"/></g></g><defs><clipPath id="clip0_15746_2423"><rect width="8" height="8" fill="white" transform="translate(12 12)"/></clipPath><clipPath id="clip1_15746_2423"><rect width="8" height="8" fill="white" transform="translate(12 12)"/></clipPath></defs></svg>',
+};
+
+const lanaOptions = { sampleRate: 1, tags: 'DC_Milo,Project Unity (DC)', severity: 'error' };
+
+window.analytics = {
+  verbAnalytics: () => {},
+  reviewAnalytics: () => {},
+  sendAnalyticsToSplunk: () => {},
+};
+
+function getSplunkEndpoint() {
+  return getEnv() === 'prod'
+    ? 'https://unity.adobe.io/api/v1/log'
+    : 'https://unity-stage.adobe.io/api/v1/log';
+}
+
+function getVerbKey(verbKey) {
+  const count = parseInt(localStorage.getItem(verbKey), 10) || 0;
+  return ({ 0: '1st', 1: '2nd' })[count] || '2+';
+}
+
+function incrementVerbKey(verbKey) {
+  const count = (parseInt(localStorage.getItem(verbKey), 10) || 0) + 1;
+  localStorage.setItem(verbKey, count);
+}
+
+async function loadAnalyticsAfterLCP(verb, userAttempts) {
+  try {
+    const { default: verbAnalytics, reviewAnalytics, sendAnalyticsToSplunk } = await import('../../scripts/alloy/verb-widget.js');
+    window.analytics.verbAnalytics = verbAnalytics;
+    window.analytics.reviewAnalytics = reviewAnalytics;
+    window.analytics.sendAnalyticsToSplunk = sendAnalyticsToSplunk;
+    window.analytics.verbAnalytics('landing:shown', verb, { userAttempts });
+    window.analytics.reviewAnalytics(verb);
+  } catch (error) {
+    window.lana?.log(
+      `Error Code: Unknown, Status: 'Unknown', Message: Analytics import failed: ${error.message} on ${verb}`,
+      lanaOptions,
+    );
+  }
+}
+
+window.addEventListener('analyticsLoad', async ({ detail }) => {
+  const delay = (ms) => new Promise((res) => { setTimeout(res, ms); });
+  if (window.PerformanceObserver) {
+    await Promise.race([
+      new Promise((res) => {
+        try {
+          const obs = new PerformanceObserver((entries) => {
+            if (entries.getEntries().length > 0) { obs.disconnect(); res(); }
+          });
+          obs.observe({ type: 'largest-contentful-paint', buffered: true });
+        } catch { res(); }
+      }),
+      delay(3000),
+    ]);
+  } else {
+    await delay(3000);
+  }
+  await loadAnalyticsAfterLCP(detail.verb, detail.userAttempts);
+});
+
+const IDB_NAME = 'dc-file-transfer';
+const IDB_STORE = 'encrypted-files';
+const IDB_VERSION = 1;
+
+function openIDB() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(IDB_NAME, IDB_VERSION);
+    req.onupgradeneeded = ({ target: { result: db } }) => {
+      if (!db.objectStoreNames.contains(IDB_STORE)) {
+        db.createObjectStore(IDB_STORE);
+      }
+    };
+    req.onsuccess = ({ target: { result } }) => resolve(result);
+    req.onerror = ({ target: { error } }) => reject(error);
+  });
+}
+
+async function storeEncryptedLocalFile(id, file) {
+  const key = await crypto.subtle.generateKey(
+    { name: 'AES-GCM', length: 256 },
+    true,
+    ['encrypt', 'decrypt'],
+  );
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    key,
+    await file.arrayBuffer(),
+  );
+  const rawKey = await crypto.subtle.exportKey('raw', key);
+
+  const db = await openIDB();
+  await new Promise((resolve, reject) => {
+    const tx = db.transaction(IDB_STORE, 'readwrite');
+    tx.objectStore(IDB_STORE).put({ ciphertext, iv, rawKey, fileName: file.name, mimeType: file.type }, id);
+    tx.oncomplete = resolve;
+    tx.onerror = ({ target: { error } }) => reject(error);
+  });
+  db.close();
+}
+
+async function storeEncryptedLocalFileChunked(id, file, { onChunkDone } = {}) {
+  const key = await crypto.subtle.generateKey(
+    { name: 'AES-GCM', length: 256 },
+    true,
+    ['encrypt', 'decrypt'],
+  );
+  const rawKey = await crypto.subtle.exportKey('raw', key);
+
+  const totalChunks = Math.ceil(file.size / CHUNK_SIZE);
+  const chunks = [];
+
+  for (let i = 0; i < totalChunks; i++) {
+    const start = i * CHUNK_SIZE;
+    const end = Math.min(start + CHUNK_SIZE, file.size);
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const ciphertext = await crypto.subtle.encrypt(
+      { name: 'AES-GCM', iv },
+      key,
+      await file.slice(start, end).arrayBuffer(),
+    );
+    chunks.push({ ciphertext, iv });
+    onChunkDone?.(end - start, i);
+  }
+
+  const db = await openIDB();
+  await new Promise((resolve, reject) => {
+    const tx = db.transaction(IDB_STORE, 'readwrite');
+    tx.objectStore(IDB_STORE).put({ chunks, rawKey, fileName: file.name, mimeType: file.type, chunked: true }, id);
+    tx.oncomplete = resolve;
+    tx.onerror = ({ target: { error } }) => reject(error);
+  });
+  db.close();
+}
+
+async function encryptAndStore(fileList, { onProgress, onChunkComplete } = {}) {
+  const totalSize = fileList.reduce((s, f) => s + f.size, 0);
+  let processed = 0;
+
+  return Promise.all(
+    fileList.map(async (file) => {
+      const id = crypto.randomUUID();
+      if (file.size >= CHUNK_THRESHOLD) {
+        await storeEncryptedLocalFileChunked(id, file, {
+          onChunkDone: (chunkBytes, chunkIndex) => {
+            processed += chunkBytes;
+            onProgress?.(processed / totalSize);
+            onChunkComplete?.(id, chunkIndex, file);
+          },
+        });
+      } else {
+        await storeEncryptedLocalFile(id, file);
+        processed += file.size;
+        onProgress?.(processed / totalSize);
+        onChunkComplete?.(id, 0, file);
+      }
+      return id;
+    }),
+  );
+}
+
+function validateFiles(files, verb) {
+  const limits = LIMITS[verb];
+  const mph = window.mph ?? {};
+
+  if (!limits || !files.length) {
+    return { valid: false, code: 'error_generic', message: mph['verb-widget-error-generic'] || 'No files selected.' };
+  }
+
+  if (!limits.multipleFiles && !limits.maxNumFiles && files.length > 1) {
+    return {
+      valid: false,
+      code: 'error_only_accept_one_file',
+      message: mph['verb-widget-error-only-accept-one-file'] || 'This tool only accepts one file at a time.',
+    };
+  }
+
+  const maxFiles = limits.maxNumFiles ?? (limits.multipleFiles ? Infinity : 1);
+  if (files.length > maxFiles) {
+    return {
+      valid: false,
+      code: 'error_max_num_files',
+      message: mph['verb-widget-error-max-num-files'] || `Maximum ${maxFiles} file${maxFiles === 1 ? '' : 's'} allowed. You selected ${files.length}.`,
+    };
+  }
+
+  const names = Array.from(files).map((f) => f.name);
+  const firstDuplicate = names.find((name, i) => names.indexOf(name) !== i);
+  if (firstDuplicate) {
+    return {
+      valid: false,
+      code: 'error_duplicate_asset',
+      message: mph['verb-widget-error-duplicate-asset'] || `Duplicate file: "${firstDuplicate}". Each file must have a unique name.`,
+    };
+  }
+
+  for (const file of files) {
+    if (file.size === 0) {
+      return {
+        valid: false,
+        code: 'error_empty_file',
+        message: mph['verb-widget-error-empty-file'] || `"${file.name}" is empty.`,
+      };
+    }
+
+    if (file.size > limits.maxFileSize) {
+      const mb = (limits.maxFileSize / 1024 / 1024).toFixed(0);
+      return {
+        valid: false,
+        code: 'error_file_too_large',
+        message: mph['verb-widget-error-file-too-large'] || `"${file.name}" exceeds the ${mb} MB size limit.`,
+      };
+    }
+
+    const ext = `.${file.name.split('.').pop().toLowerCase()}`;
+    if (limits.acceptedFiles && !limits.acceptedFiles.includes(ext)) {
+      return {
+        valid: false,
+        code: 'error_unsupported_type',
+        message: mph['verb-widget-error-unsupported-type'] || `"${file.name}" is not a supported file type.`,
+      };
+    }
+
+    const allowedMimes = MIME_TYPES[ext];
+    if (file.type && allowedMimes && !allowedMimes.includes(file.type)) {
+      return {
+        valid: false,
+        code: 'error_unsupported_type',
+        message: mph['verb-widget-error-unsupported-type'] || `"${file.name}" doesn't appear to be a valid ${ext.slice(1).toUpperCase()} file.`,
+      };
+    }
+  }
+
+  return { valid: true };
+}
+
+const svgCache = new Map();
+
+async function loadSvg(iconName) {
+  try {
+    const response = await fetch(`/acrobat/blocks/verb-widget/icons/${iconName}.svg`);
+    if (!response.ok) throw new Error(`Failed to load SVG: ${response.statusText}`);
+    return await response.text();
+  } catch (error) {
+    window.lana?.log(`Error Code: Unknown, Status: 'Unknown', Message: Icon not found: ${iconName}`, lanaOptions);
+    return null;
+  }
+}
+
+async function createSvgElement(iconName) {
+  if (svgCache.has(iconName)) return svgCache.get(iconName).cloneNode(true);
+  const svgString = ICONS[iconName] || await loadSvg(iconName);
+  if (!svgString) return null;
+  const doc = new DOMParser().parseFromString(svgString, 'image/svg+xml');
+  svgCache.set(iconName, doc.documentElement);
+  return doc.documentElement.cloneNode(true);
+}
+
+export default async function init(element) {
+  ({ createTag, getConfig } = await import(`${miloLibs}/utils/utils.js`));
+
+  if (isOldBrowser()) {
+    window.location.href = EOLBrowserPage;
+    return;
+  }
+
+  const { locale } = getConfig();
+  const ppURL = window.mph?.['verb-widget-privacy-policy-url']
+    || `https://www.adobe.com${locale.prefix}/privacy/policy.html`;
+  const touURL = window.mph?.['verb-widget-terms-of-use-url']
+    || `https://www.adobe.com${locale.prefix}/legal/terms.html`;
+
+  const children = [...element.querySelectorAll(':scope > div')];
+  const VERB = element.classList[1];
+  const limits = LIMITS[VERB] ?? LIMITS['image-to-pdf'];
+  const userAttempts = getVerbKey(`${VERB}_attempts`);
+
+  const heading = children[0]?.textContent ?? '';
+  const subCopy = children[1]?.textContent ?? window.mph?.[`verb-widget-${VERB}-description`] ?? '';
+  const ctaLabel = window.mph?.['verb-widget-cta'] ?? 'Select a file';
+
+  children.forEach((c) => c.remove());
+
+  const widget = createTag('div', { id: 'drop-zone', class: 'verb-wrapper' });
+  const widgetContainer = createTag('div', { class: 'verb-container' });
+  const widgetRow = createTag('div', { class: 'verb-row' });
+  const widgetLeft = createTag('div', { class: 'verb-col' });
+  const widgetRight = createTag('div', { class: 'verb-col right' });
+
+  const widgetHeader = createTag('div', { class: 'verb-header' });
+  const widgetIcon = createTag('div', { class: 'acrobat-icon' });
+  const widgetIconSvg = await createSvgElement('WIDGET_ICON');
+  if (widgetIconSvg) { widgetIconSvg.classList.add('icon-verb'); widgetIcon.appendChild(widgetIconSvg); }
+  const widgetTitle = createTag('div', { class: 'verb-title' }, 'Adobe Acrobat');
+  widgetHeader.append(widgetIcon, widgetTitle);
+
+  const widgetHeading = createTag('h1', { class: 'verb-heading' }, heading);
+  const widgetCopy = createTag('p', { class: 'verb-copy' }, subCopy);
+
+  const errorState = createTag('div', { class: 'error hide' });
+  const errorIcon = createTag('div', { class: 'verb-errorIcon' });
+  const errorText = createTag('p', { class: 'verb-errorText' });
+  const closeErrorBtn = createTag('div', { class: 'verb-errorBtn', role: 'button', tabindex: '0', 'aria-label': 'Close error' });
+  const closeIconSvg = await createSvgElement('CLOSE_ICON');
+  if (closeIconSvg) { closeIconSvg.classList.add('close-icon', 'error'); closeErrorBtn.prepend(closeIconSvg); }
+
+  const ctaButton = createTag('button', { for: 'file-upload', class: 'verb-cta', tabindex: 0, 'aria-label': ctaLabel });
+  const uploadIconSvg = await createSvgElement('UPLOAD_ICON');
+  if (uploadIconSvg) { uploadIconSvg.classList.add('upload-icon'); ctaButton.prepend(uploadIconSvg); }
+  ctaButton.append(createTag('span', { class: 'verb-cta-label' }, ctaLabel));
+
+  const fileInput = createTag('input', {
+    type: 'file',
+    accept: limits.acceptedFiles?.join(','),
+    id: 'file-upload',
+    class: 'hide',
+    'aria-hidden': 'true',
+    ...(limits.multipleFiles && { multiple: '' }),
+  });
+
+  const progressContainer = createTag('div', { class: 'upload-progress hide' });
+  const progressLabel = createTag('div', { class: 'upload-progress-label' });
+  const progressBar = createTag('div', { class: 'upload-progress-bar' });
+  const progressFill = createTag('div', { class: 'upload-progress-fill' });
+  progressBar.append(progressFill);
+  progressContainer.append(progressLabel, progressBar);
+
+  const widgetImage = createTag('div', { class: 'verb-image' });
+  const verbImageSvg = await createSvgElement(VERB);
+  if (verbImageSvg) {
+    verbImageSvg.classList.add('icon-verb-image');
+    verbImageSvg.setAttribute('alt', window.mph?.[`verb-widget-${VERB}-alt`] || VERB);
+    widgetImage.appendChild(verbImageSvg);
+  }
+
+  const footer = createTag('div', { class: 'verb-footer' });
+  const iconSecurity = createTag('div', { class: 'security-icon' });
+  const infoIcon = createTag('div', {
+    class: 'info-icon milo-tooltip top',
+    tabindex: '0',
+    role: 'button',
+    'aria-label': window.mph?.['verb-widget-tool-tip'] || 'Files security information',
+    'data-tooltip': window.mph?.['verb-widget-tool-tip'] || '',
+  });
+  const securityIconSvg = await createSvgElement('SECURITY_ICON');
+  const infoIconSvg = await createSvgElement('INFO_ICON');
+  if (securityIconSvg) { iconSecurity.appendChild(securityIconSvg); infoIcon.appendChild(infoIconSvg); }
+  const legalWrapper = createTag('div', { class: 'verb-legal-wrapper' });
+  const legal = createTag('p', { class: 'verb-legal' }, `${window.mph?.['verb-widget-legal'] ?? ''} `);
+  const legalTwo = createTag('p', { class: 'verb-legal verb-legal-two' });
+  legalTwo.innerHTML = [
+    { key: 'verb-widget-terms-of-use', url: touURL },
+    { key: 'verb-widget-privacy-policy', url: ppURL },
+  ].reduce((html, { key, url }) => {
+    const text = window.mph?.[key];
+    return text ? html.replace(text, `<a class="verb-legal-url" target="_blank" href="${url}">${text}</a>`) : html;
+  }, `${window.mph?.['verb-widget-legal-2'] ?? ''} `);
+  legalWrapper.append(legal, legalTwo);
+  footer.append(iconSecurity, legalWrapper, infoIcon);
+
+  errorState.append(errorIcon, errorText, closeErrorBtn);
+  widgetLeft.append(widgetHeader, widgetHeading, widgetCopy, errorState, ctaButton, fileInput, progressContainer);
+  widgetRight.append(widgetImage);
+  widgetRow.append(widgetLeft, widgetRight);
+  widgetContainer.append(widgetRow);
+  widget.append(widgetContainer);
+  element.append(widget, footer);
+  element.parentNode.style.display = 'block';
+
+  const setProgress = (ratio, label = '') => {
+    const pct = Math.round(ratio * 100);
+    progressFill.style.width = `${pct}%`;
+    progressLabel.textContent = label || `${pct}%`;
+    progressFill.setAttribute('aria-valuenow', pct);
+  };
+
+  const hideProgress = () => {
+    progressContainer.classList.add('hide');
+    ctaButton.classList.remove('hide');
+    setProgress(0);
+  };
+
+  const showError = (message) => {
+    errorText.textContent = message;
+    errorState.classList.remove('hide');
+    errorState.classList.add('verb-error');
+    widget.classList.remove('dragging');
+  };
+
+  const hideError = () => {
+    errorState.classList.add('hide');
+    errorState.classList.remove('verb-error');
+    errorText.textContent = '';
+  };
+
+  let exitFlag = false;
+  let isUploading = false;
+
+  function setCookie(name, value) {
+    const expires = new Date(Date.now() + 30 * 60 * 1000).toUTCString();
+    document.cookie = `${name}=${value};domain=.adobe.com;path=/;expires=${expires}`;
+  }
+
+  function getUploadTime() {
+    const uploading = parseInt(document.cookie.match(/UTS_Uploading=([^;]*)/)?.[1], 10);
+    const uploaded = parseInt(document.cookie.match(/UTS_Uploaded=([^;]*)/)?.[1], 10);
+    if (Number.isNaN(uploading) || Number.isNaN(uploaded)) return 'N/A';
+    return ((uploaded - uploading) / 1000).toFixed(1);
+  }
+
+  function getFileType(files) {
+    const types = [...new Set(files.map((f) => f.type))];
+    return types.length > 1 ? 'mixed' : types[0] || '';
+  }
+
+  const errorAnalyticsMap = {
+    error_only_accept_one_file: 'error_only_accept_one_file',
+    error_unsupported_type: 'error:UnsupportedFile',
+    error_empty_file: 'error:EmptyFile',
+    error_file_too_large: 'error:TooLargeFile',
+    error_max_num_files: 'error:max_num_files',
+    error_duplicate_asset: 'error:duplicate_asset',
+    error_generic: 'error',
+  };
+
+  function handleAnalyticsEvent(eventName, metadata, documentUnloading = true) {
+    window.analytics.verbAnalytics(eventName, VERB, metadata, documentUnloading);
+    window.analytics.sendAnalyticsToSplunk(eventName, VERB, metadata, getSplunkEndpoint());
+  }
+
+  function dispatchError(code, message, metadata = {}) {
+    showError(message);
+    window.lana?.log(`Error Code: ${code}, Message: ${message}`, lanaOptions);
+    const analyticsKey = Object.keys(errorAnalyticsMap).find((k) => code.includes(k));
+    if (analyticsKey) {
+      window.analytics.verbAnalytics(errorAnalyticsMap[analyticsKey], VERB, analyticsKey === 'error_generic' ? { errorInfo: message } : {});
+      window.analytics.sendAnalyticsToSplunk(analyticsKey, VERB, metadata, getSplunkEndpoint());
+    }
+    exitFlag = true;
+  }
+
+  async function startUpload(files) {
+    hideError();
+
+    const filesData = {
+      userAttempts,
+      size: files.reduce((s, f) => s + f.size, 0),
+      type: getFileType(files),
+      count: files.length,
+      uploadType: files.length > 1 ? 'mfu' : 'sfu',
+    };
+
+    isUploading = true;
+    exitFlag = false;
+    setCookie('UTS_Uploading', Date.now());
+    handleAnalyticsEvent('job:uploading', filesData, false);
+    if (files.length > 1) handleAnalyticsEvent('job:multi-file-uploading', filesData, false);
+
+    progressContainer.classList.remove('hide');
+    ctaButton.classList.add('hide');
+    setProgress(0, 'Encrypting…');
+
+    try {
+      const ids = await encryptAndStore(files, {
+        onProgress: (ratio) => setProgress(ratio, `Encrypting… ${Math.round(ratio * 100)}%`),
+        onChunkComplete: (id, chunkIndex, file) => {
+          window.analytics.sendAnalyticsToSplunk('job:chunk-uploaded', VERB, {
+            ...filesData,
+            assetId: id,
+            chunkNumber: chunkIndex,
+            chunkUploadAttempt: 1,
+          }, getSplunkEndpoint());
+        },
+      });
+
+      setCookie('UTS_Uploaded', Date.now());
+      exitFlag = true;
+      isUploading = false;
+      incrementVerbKey(`${VERB}_attempts`);
+
+      const uploadTime = getUploadTime();
+      handleAnalyticsEvent('job:uploaded', { ...filesData, assetId: ids[0], uploadTime }, false);
+      if (files.length > 1) handleAnalyticsEvent('job:multi-file-uploaded', filesData, false);
+
+      setProgress(1, 'Done');
+
+      const redirectBase = window.mph?.['verb-widget-client-upload-redirect'];
+      if (redirectBase) {
+        const params = new URLSearchParams({ fileId: ids.join(',') });
+        const redirectUrl = `${redirectBase}?${params}`;
+        handleAnalyticsEvent('job:redirect-success', { ...filesData, redirectUrl }, false);
+        window.location.href = redirectUrl;
+      } else {
+        hideProgress();
+      }
+    } catch (err) {
+      isUploading = false;
+      hideProgress();
+      dispatchError('error_generic', err.message || 'Failed to store file. Please try again.', filesData);
+    }
+  }
+
+  fileInput.addEventListener('change', ({ target: { files } }) => {
+    if (!files?.length) return;
+    exitFlag = false;
+    handleAnalyticsEvent('choose-file:open', { userAttempts }, true);
+    const validation = validateFiles(files, VERB);
+    if (!validation.valid) { dispatchError(validation.code, validation.message, { userAttempts }); return; }
+    startUpload(Array.from(files));
+  });
+
+  widget.addEventListener('click', (e) => {
+    if (e.target.closest('.error')) return;
+    fileInput.click();
+  });
+
+  widget.addEventListener('dragover', (e) => {
+    e.preventDefault();
+    widget.classList.add('dragging');
+  });
+
+  widget.addEventListener('dragleave', () => widget.classList.remove('dragging'));
+
+  widget.addEventListener('drop', (e) => {
+    e.preventDefault();
+    widget.classList.remove('dragging');
+    const { files } = e.dataTransfer;
+    if (!files?.length) return;
+    exitFlag = false;
+    ['files-dropped', 'entry:clicked', 'discover:clicked'].forEach((evt) => {
+      handleAnalyticsEvent(evt, { userAttempts }, true);
+    });
+    const validation = validateFiles(files, VERB);
+    if (!validation.valid) { dispatchError(validation.code, validation.message, { userAttempts }); return; }
+    startUpload(Array.from(files));
+  });
+
+  closeErrorBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    hideError();
+  });
+
+  window.addEventListener('beforeunload', (e) => {
+    const cookieExp = new Date(Date.now() + 90 * 1000).toUTCString();
+    if (exitFlag) {
+      document.cookie = `UTS_Redirect=${Date.now()};domain=.adobe.com;path=/;expires=${cookieExp}`;
+    }
+    if (isUploading) {
+      e.preventDefault();
+      e.returnValue = true;
+    }
+  });
+
+  window.addEventListener('pageshow', (e) => {
+    const historyTraversal = e.persisted
+      || (typeof window.performance !== 'undefined'
+        && window.performance.getEntriesByType('navigation')[0].type === 'back_forward');
+    if (historyTraversal) window.location.reload();
+  });
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => {
+      window.dispatchEvent(new CustomEvent('analyticsLoad', { detail: { verb: VERB, userAttempts } }));
+    });
+  } else {
+    window.dispatchEvent(new CustomEvent('analyticsLoad', { detail: { verb: VERB, userAttempts } }));
+  }
+}

--- a/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.js
+++ b/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.js
@@ -621,10 +621,11 @@ export default async function init(element) {
       const uploadedMetadata = { ...filesData, assetId: id, uploadTime };
       handleAnalyticsEvent('job:uploaded', uploadedMetadata, false);
 
-      const redirectBase = window.mph?.['verb-widget-client-upload-redirect']
-        || 'https://mwpw-197746--da-dc--adobecom.aem.live/acrobat/online';
+      const redirectBase = DC_ENV === 'prod'
+        ? 'https://www.adobe.com/acrobat-online/image-to-pdf.html'
+        : 'https://www.stage.adobe.com/acrobat-online/image-to-pdf.html';
       const [baseUrl, queryString] = redirectBase.split('?');
-      const redirectUrl = `${baseUrl}?clientConvert=true&UTS_Uploaded=${uploadTimestamp}&redirectTime=${Date.now()}&fileId=${id}${queryString ? `&${queryString}` : ''}`;
+      const redirectUrl = `${baseUrl}?clientConvert=true&UTS_Uploaded=${uploadTimestamp}&redirectTime=${Date.now()}&fileId=${id}${queryString ? `&${queryString}` : ''}&force_meteriq=true`;
       handleAnalyticsEvent('job:redirect-success', { ...filesData, redirectUrl }, false);
       window.location.href = redirectUrl;
     } catch (err) {

--- a/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.js
+++ b/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.js
@@ -671,7 +671,7 @@ export default async function init(element) {
     exitFlag = false;
     setCookie('UTS_Uploading', Date.now());
     handleAnalyticsEvent('job:uploading', filesData, false);
-    if (files.length > 1) handleAnalyticsEvent('job:multi-file-uploading', filesData, false);
+    if (LIMITS[VERB]?.multipleFiles) handleAnalyticsEvent('job:multi-file-uploading', filesData, false);
 
     progressContainer.classList.remove('hide');
     ctaButton.classList.add('hide');
@@ -697,8 +697,9 @@ export default async function init(element) {
       setUser();
 
       const uploadTime = getUploadTime();
-      handleAnalyticsEvent('job:uploaded', { ...filesData, assetId: ids[0], uploadTime }, false);
-      if (files.length > 1) handleAnalyticsEvent('job:multi-file-uploaded', filesData, false);
+      const uploadedMetadata = { ...filesData, assetId: ids[0], uploadTime };
+      handleAnalyticsEvent('job:uploaded', uploadedMetadata, false);
+      if (LIMITS[VERB]?.multipleFiles) handleAnalyticsEvent('job:multi-file-uploaded', uploadedMetadata, false);
 
       setProgress(1, 'Done');
 
@@ -714,6 +715,20 @@ export default async function init(element) {
       dispatchError('error_generic', err.message || 'Failed to store file. Please try again.', filesData);
     }
   }
+
+  fileInput.addEventListener('click', () => {
+    [
+      'filepicker:shown',
+      'dropzone:choose-file-clicked',
+      'files-selected',
+      'entry:clicked',
+      'discover:clicked',
+    ].forEach((evt) => window.analytics.verbAnalytics(evt, VERB, { userAttempts }));
+  });
+
+  fileInput.addEventListener('cancel', () => {
+    window.analytics.verbAnalytics('choose-file:close', VERB, { userAttempts });
+  });
 
   fileInput.addEventListener('change', ({ target: { files } }) => {
     if (!files?.length) return;

--- a/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.js
+++ b/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.js
@@ -208,11 +208,11 @@ window.addEventListener('analyticsLoad', async ({ detail }) => {
   await loadAnalyticsAfterLCP(detail.verb, detail.userAttempts);
 });
 
-const IDB_NAME = 'dc-file-transfer';
-const IDB_STORE = 'encrypted-files';
+export const IDB_NAME = 'dc-file-transfer';
+export const IDB_STORE = 'encrypted-files';
 const IDB_VERSION = 1;
 
-function openIDB() {
+export function openIDB() {
   return new Promise((resolve, reject) => {
     const req = indexedDB.open(IDB_NAME, IDB_VERSION);
     req.onupgradeneeded = ({ target: { result: db } }) => {
@@ -225,7 +225,7 @@ function openIDB() {
   });
 }
 
-async function storeEncryptedLocalFile(id, file) {
+export async function storeEncryptedLocalFile(id, file) {
   const key = await crypto.subtle.generateKey(
     { name: 'AES-GCM', length: 256 },
     false,
@@ -249,13 +249,13 @@ async function storeEncryptedLocalFile(id, file) {
   db.close();
 }
 
-async function encryptAndStore(file) {
+export async function encryptAndStore(file) {
   const id = crypto.randomUUID();
   await storeEncryptedLocalFile(id, file);
   return id;
 }
 
-function validateFiles(files, verb) {
+export function validateFiles(files, verb) {
   const limits = LIMITS[verb];
   const mph = window.mph ?? {};
 

--- a/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.js
+++ b/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.js
@@ -4,6 +4,10 @@ const miloLibs = setLibs('/libs');
 
 let createTag;
 let getConfig;
+let loadBlock;
+let getMetadata;
+let loadIms;
+let loadScript;
 
 const EOLBrowserPage = 'https://acrobat.adobe.com/home/index-browser-eol.html';
 
@@ -14,6 +18,55 @@ const ALL_FILES = ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.x
 
 const LIMITS = {
   'image-to-pdf': { maxFileSize: MB100, acceptedFiles: ALL_FILES, multipleFiles: true },
+};
+
+const DC_ENV = ['www.adobe.com', 'sign.ing', 'edit.ing'].includes(window.location.hostname) ? 'prod' : 'stage';
+
+const fallBack = 'https://www.adobe.com/go/acrobat-overview';
+
+const verbRedirMap = {
+  createpdf: 'createpdf',
+  'crop-pages': 'crop',
+  'delete-pages': 'deletepages',
+  'extract-pages': 'extract',
+  'combine-pdf': 'combine',
+  'protect-pdf': 'protect',
+  'add-comment': 'addcomment',
+  'pdf-to-image': 'pdftoimage',
+  'reorder-pages': 'reorderpages',
+  sendforsignature: 'sendforsignature',
+  'rotate-pages': 'rotatepages',
+  fillsign: 'fillsign',
+  'split-pdf': 'split',
+  'insert-pdf': 'insert',
+  'compress-pdf': 'compress',
+  'png-to-pdf': 'jpgtopdf',
+  'image-to-pdf': 'jpgtopdf',
+  'bmp-to-pdf': 'jpgtopdf',
+  'gif-to-pdf': 'jpgtopdf',
+  'tiff-to-pdf': 'jpgtopdf',
+  'indd-to-pdf': 'createpdf',
+  'psd-to-pdf': 'createpdf',
+  'ai-to-pdf': 'createpdf',
+  'number-pages': 'number',
+  'ocr-pdf': 'ocr',
+  'chat-pdf': 'chat',
+  'chat-pdf-student': 'study',
+};
+
+const exhLimitCookieMap = {
+  'to-pdf': 'cr_p_c',
+  'pdf-to': 'ex_p_c',
+  'combine-pdf': 'cb_p_c',
+  'compress-pdf': 'cm_p_ops',
+  'rotate-pages': 'or_p_c',
+  createpdf: 'cr_p_c',
+  'ocr-pdf': 'ocr_p_c',
+};
+
+const appEnvCookieMap = {
+  stage: 's_ta_',
+  prod: 'p_ac_',
 };
 
 const MIME_TYPES = {
@@ -43,6 +96,74 @@ const ICONS = {
   INFO_ICON: '<svg viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg"><g opacity="0.8"><path d="M9.00078 7.0748C9.59449 7.0748 10.0758 6.59351 10.0758 5.9998C10.0758 5.4061 9.59449 4.9248 9.00078 4.9248C8.40707 4.9248 7.92578 5.4061 7.92578 5.9998C7.92578 6.59351 8.40707 7.0748 9.00078 7.0748Z" fill="#222222"/><path fill-rule="evenodd" clip-rule="evenodd" d="M10.167 12H10V8.2C10 8.14696 9.97893 8.09609 9.94142 8.05858C9.90391 8.02107 9.85304 8 9.8 8H7.833C7.833 8 7.25 8.016 7.25 8.5C7.25 8.984 7.833 9 7.833 9H8V12H7.833C7.833 12 7.25 12.016 7.25 12.5C7.25 12.984 7.833 13 7.833 13H10.167C10.167 13 10.75 12.984 10.75 12.5C10.75 12.016 10.167 12 10.167 12Z" fill="#222222"/><path fill-rule="evenodd" clip-rule="evenodd" d="M9.00078 1.0498C7.42842 1.0498 5.89137 1.51606 4.584 2.38962C3.27663 3.26318 2.25766 4.5048 1.65594 5.95747C1.05423 7.41014 0.896789 9.00862 1.20354 10.5508C1.51029 12.0929 2.26746 13.5095 3.37929 14.6213C4.49111 15.7331 5.90767 16.4903 7.44982 16.797C8.99197 17.1038 10.5904 16.9464 12.0431 16.3446C13.4958 15.7429 14.7374 14.724 15.611 13.4166C16.4845 12.1092 16.9508 10.5722 16.9508 8.9998C16.9508 6.89133 16.1132 4.86922 14.6223 3.37831C13.1314 1.88739 11.1093 1.0498 9.00078 1.0498ZM9.00078 15.9558C7.62502 15.9558 6.28015 15.5478 5.13624 14.7835C3.99233 14.0192 3.10076 12.9328 2.57428 11.6618C2.0478 10.3907 1.91004 8.99209 2.17844 7.64276C2.44684 6.29342 3.10934 5.05398 4.08215 4.08117C5.05496 3.10836 6.2944 2.44586 7.64374 2.17746C8.99307 1.90906 10.3917 2.04682 11.6627 2.5733C12.9338 3.09978 14.0202 3.99135 14.7845 5.13526C15.5488 6.27917 15.9568 7.62404 15.9568 8.9998C15.9568 10.8447 15.2239 12.6139 13.9194 13.9184C12.6149 15.2229 10.8456 15.9558 9.00078 15.9558Z" fill="#222222"/></g></svg>',
   CLOSE_ICON: '<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg"><g clip-path="url(#clip0_15746_2423)"><g clip-path="url(#clip1_15746_2423)"><path fill-rule="evenodd" clip-rule="evenodd" d="M17.2381 15.9994L19.6944 13.5434C19.8586 13.3793 19.9509 13.1566 19.9509 12.9245C19.951 12.6923 19.8588 12.4696 19.6946 12.3054C19.5305 12.1412 19.3078 12.0489 19.0757 12.0488C18.8435 12.0488 18.6208 12.141 18.4566 12.3051L16.0002 14.7615L13.5435 12.3051C13.3793 12.141 13.1566 12.0489 12.9245 12.049C12.6923 12.0491 12.4697 12.1414 12.3057 12.3056C12.1416 12.4698 12.0495 12.6925 12.0496 12.9246C12.0497 13.1568 12.142 13.3794 12.3062 13.5434L14.7622 15.9994L12.3062 18.4555C12.1427 18.6197 12.051 18.8421 12.0512 19.0738C12.0515 19.3055 12.1436 19.5277 12.3074 19.6916C12.4711 19.8556 12.6933 19.9478 12.925 19.9482C13.1567 19.9486 13.3791 19.8571 13.5435 19.6938L16.0002 17.2374L18.4566 19.6938C18.6208 19.8579 18.8435 19.9501 19.0756 19.9501C19.3078 19.95 19.5305 19.8577 19.6946 19.6935C19.8588 19.5293 19.9509 19.3066 19.9509 19.0745C19.9509 18.8423 19.8586 18.6196 19.6944 18.4555L17.2381 15.9994Z" fill="white"/></g></g><defs><clipPath id="clip0_15746_2423"><rect width="8" height="8" fill="white" transform="translate(12 12)"/></clipPath><clipPath id="clip1_15746_2423"><rect width="8" height="8" fill="white" transform="translate(12 12)"/></clipPath></defs></svg>',
 };
+
+function isMobileDevice() {
+  return /android|iphone|ipod|blackberry|windows phone/i.test(navigator.userAgent);
+}
+
+function isTabletDevice() {
+  const ua = navigator.userAgent.toLowerCase();
+  const isIPadOS = navigator.userAgent.includes('Mac') && 'ontouchend' in document && !/iphone|ipod/i.test(ua);
+  return isIPadOS || /ipad|android(?!.*mobile)/i.test(ua);
+}
+
+function redDirLink(verb) {
+  const hostname = window?.location?.hostname;
+  const ENV = getEnv();
+  if (hostname !== 'www.adobe.com' && hostname !== 'sign.ing' && hostname !== 'edit.ing') {
+    return `https://www.adobe.com/go/acrobat-${verbRedirMap[verb] || verb.split('-').join('')}-${ENV}`;
+  }
+  return `https://www.adobe.com/go/acrobat-${verbRedirMap[verb] || verb.split('-').join('')}` || fallBack;
+}
+
+function redDir(verb) {
+  window.location.href = redDirLink(verb);
+}
+
+async function loadGoogleLogin() {
+  if (window.adobeIMS?.isSignedInUser()) return;
+  const { default: initGoogleLogin } = await import(`${miloLibs}/features/google-login.js`);
+  initGoogleLogin(loadIms, getMetadata, loadScript, getConfig);
+}
+
+async function showUpSell(verb, element) {
+  const headline = window.mph?.[`verb-widget-upsell-headline-${verb}`] || window.mph?.['verb-widget-upsell-headline'];
+  const headlineNopayment = window.mph?.['verb-widget-upsell-headline-nopayment'];
+  const bulletsHeading = window.mph?.['verb-widget-upsell-bullets-heading'];
+  const bullets = window.mph?.[`verb-widget-upsell-bullets-${verb}`] || window.mph?.['verb-widget-upsell-bullets'];
+
+  const headlineEl = createTag('h1', { class: 'verb-upsell-heading' }, headline);
+  const headingNopaymentEl = createTag('h1', { class: 'verb-upsell-heading verb-upsell-heading-nopayment' }, headlineNopayment);
+  const upsellBulletsHeading = createTag('p', { class: 'verb-upsell-bullets-heading' }, bulletsHeading);
+  const upsellBullets = createTag('ul', { class: 'verb-upsell-bullets' });
+  (bullets || '').split('\n').forEach((bullet) => upsellBullets.append(createTag('li', {}, bullet)));
+
+  const upsell = createTag('div', { class: 'verb-upsell' });
+  const upsellColumn = createTag('div', { class: 'verb-upsell-column' });
+
+  const socialContainer = createTag('div', { class: 'verb-upsell-social-container' });
+  const socialCta = createTag('div', { class: 'susi-light' });
+  socialCta.innerHTML = `<div><div>${redDirLink(verb)}</div></div>`;
+  socialContainer.append(socialCta);
+  await loadBlock(socialCta);
+
+  const upsellRow = createTag('div', { class: 'verb-row' });
+  upsellRow.append(upsellColumn, socialContainer);
+  upsell.append(upsellRow);
+  upsellColumn.append(headlineEl, headingNopaymentEl, upsellBulletsHeading, upsellBullets);
+
+  const upsellWidget = createTag('div', { class: 'verb-wrapper verb-upsell-active' });
+  const upsellContainer = createTag('div', { class: 'verb-container' });
+  upsellWidget.append(upsellContainer);
+  upsellContainer.append(upsell);
+
+  element.classList.add('upsell');
+  element.append(upsellWidget);
+
+  loadGoogleLogin();
+}
+
+const setUser = () => { localStorage.setItem('unity.user', 'true'); };
 
 const lanaOptions = { sampleRate: 1, tags: 'DC_Milo,Project Unity (DC)', severity: 'error' };
 
@@ -303,7 +424,9 @@ async function createSvgElement(iconName) {
 }
 
 export default async function init(element) {
-  ({ createTag, getConfig } = await import(`${miloLibs}/utils/utils.js`));
+  ({
+    createTag, getConfig, loadBlock, getMetadata, loadIms, loadScript,
+  } = await import(`${miloLibs}/utils/utils.js`));
 
   if (isOldBrowser()) {
     window.location.href = EOLBrowserPage;
@@ -320,6 +443,8 @@ export default async function init(element) {
   const VERB = element.classList[1];
   const limits = LIMITS[VERB] ?? LIMITS['image-to-pdf'];
   const userAttempts = getVerbKey(`${VERB}_attempts`);
+  const isMobile = isMobileDevice();
+  const isTablet = isTabletDevice();
 
   const heading = children[0]?.textContent ?? '';
   const subCopy = children[1]?.textContent ?? window.mph?.[`verb-widget-${VERB}-description`] ?? '';
@@ -402,7 +527,20 @@ export default async function init(element) {
     return text ? html.replace(text, `<a class="verb-legal-url" target="_blank" href="${url}">${text}</a>`) : html;
   }, `${window.mph?.['verb-widget-legal-2'] ?? ''} `);
   legalWrapper.append(legal, legalTwo);
+  if (isMobile) {
+    widget.classList.add('mobile');
+    infoIcon.classList.add('mobile');
+  } else if (isTablet) {
+    widget.classList.add('tablet');
+    infoIcon.classList.add('tablet');
+  }
+
   footer.append(iconSecurity, legalWrapper, infoIcon);
+
+  if (isMobile && !isTablet) {
+    iconSecurity.remove();
+    footer.prepend(infoIcon);
+  }
 
   errorState.append(errorIcon, errorText, closeErrorBtn);
   widgetLeft.append(widgetHeader, widgetHeading, widgetCopy, errorState, ctaButton, fileInput, progressContainer);
@@ -411,7 +549,40 @@ export default async function init(element) {
   widgetContainer.append(widgetRow);
   widget.append(widgetContainer);
   element.append(widget, footer);
+  element.classList.add('ready');
   element.parentNode.style.display = 'block';
+
+  async function checkSignedInUser() {
+    if (!window.adobeIMS?.isSignedInUser?.()) return;
+
+    element.classList.remove('upsell');
+    element.classList.add('signed-in');
+
+    let accountType;
+    try {
+      accountType = window.adobeIMS.getAccountType();
+    } catch {
+      accountType = (await window.adobeIMS.getProfile()).account_type;
+    }
+
+    if (accountType && LIMITS[VERB].neverRedirect) return;
+    if (accountType !== 'type1') redDir(VERB);
+    if (accountType === 'type1' && !LIMITS[VERB].typeOneLanding) redDir(VERB);
+  }
+
+  const { cookie } = document;
+  const limitCookie = exhLimitCookieMap[VERB] || exhLimitCookieMap[VERB.match(/^pdf-to|to-pdf$/)?.[0]];
+  const cookiePrefix = appEnvCookieMap[DC_ENV] || '';
+  const isLimitExhausted = limitCookie && cookie.includes(`${cookiePrefix}${limitCookie}`);
+
+  if (!window.adobeIMS?.isSignedInUser?.() && isLimitExhausted) {
+    await showUpSell(VERB, element);
+    window.analytics.verbAnalytics('upsell:shown', VERB, { userAttempts });
+    window.analytics.verbAnalytics('upsell-wall:shown', VERB, { userAttempts });
+  }
+
+  await checkSignedInUser();
+  window.addEventListener('IMS:Ready', checkSignedInUser);
 
   const setProgress = (ratio, label = '') => {
     const pct = Math.round(ratio * 100);
@@ -523,6 +694,7 @@ export default async function init(element) {
       exitFlag = true;
       isUploading = false;
       incrementVerbKey(`${VERB}_attempts`);
+      setUser();
 
       const uploadTime = getUploadTime();
       handleAnalyticsEvent('job:uploaded', { ...filesData, assetId: ids[0], uploadTime }, false);
@@ -530,15 +702,12 @@ export default async function init(element) {
 
       setProgress(1, 'Done');
 
-      const redirectBase = window.mph?.['verb-widget-client-upload-redirect'];
-      if (redirectBase) {
-        const params = new URLSearchParams({ fileId: ids.join(',') });
-        const redirectUrl = `${redirectBase}?${params}`;
-        handleAnalyticsEvent('job:redirect-success', { ...filesData, redirectUrl }, false);
-        window.location.href = redirectUrl;
-      } else {
-        hideProgress();
-      }
+      const redirectBase = window.mph?.['verb-widget-client-upload-redirect']
+        || 'https://www.stage.adobe.com/acrobat/online.html';
+      const params = new URLSearchParams({ fileId: ids.join(',') });
+      const redirectUrl = `${redirectBase}?${params}`;
+      handleAnalyticsEvent('job:redirect-success', { ...filesData, redirectUrl }, false);
+      window.location.href = redirectUrl;
     } catch (err) {
       isUploading = false;
       hideProgress();

--- a/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.js
+++ b/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.js
@@ -622,7 +622,7 @@ export default async function init(element) {
       handleAnalyticsEvent('job:uploaded', uploadedMetadata, false);
 
       const redirectBase = window.mph?.['verb-widget-client-upload-redirect']
-        || 'https://mwpw-197746--da-dc--adobecom.aem.page/acrobat/online';
+        || 'https://mwpw-197746--da-dc--adobecom.aem.live/acrobat/online';
       const [baseUrl, queryString] = redirectBase.split('?');
       const redirectUrl = `${baseUrl}?UTS_Uploaded=${uploadTimestamp}&redirectTime=${Date.now()}&fileId=${id}${queryString ? `&${queryString}` : ''}`;
       handleAnalyticsEvent('job:redirect-success', { ...filesData, redirectUrl }, false);

--- a/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.js
+++ b/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.js
@@ -604,14 +604,11 @@ export default async function init(element) {
     setCookie('UTS_Uploading', Date.now());
     handleAnalyticsEvent('job:uploading', filesData, false);
 
-    progressContainer.classList.remove('hide');
-    ctaButton.classList.add('hide');
-    setProgress(0, 'Encrypting…');
+    ctaButton.disabled = true;
+    ctaButton.querySelector('.verb-cta-label').textContent = window.mph?.['verb-widget-processing'] || 'Processing…';
 
     try {
-      const id = await encryptAndStore(file, {
-        onProgress: (ratio) => setProgress(ratio, `Encrypting… ${Math.round(ratio * 100)}%`),
-      });
+      const id = await encryptAndStore(file);
 
       const uploadTimestamp = Date.now();
       setCookie('UTS_Uploaded', uploadTimestamp);
@@ -624,8 +621,6 @@ export default async function init(element) {
       const uploadedMetadata = { ...filesData, assetId: id, uploadTime };
       handleAnalyticsEvent('job:uploaded', uploadedMetadata, false);
 
-      setProgress(1, 'Done');
-
       const redirectBase = window.mph?.['verb-widget-client-upload-redirect']
         || 'https://mwpw-197746--da-dc--adobecom.aem.page/acrobat/online';
       const [baseUrl, queryString] = redirectBase.split('?');
@@ -634,7 +629,8 @@ export default async function init(element) {
       window.location.href = redirectUrl;
     } catch (err) {
       isUploading = false;
-      hideProgress();
+      ctaButton.disabled = false;
+      ctaButton.querySelector('.verb-cta-label').textContent = ctaLabel;
       dispatchError('error_generic', err.message || 'Failed to store file. Please try again.', filesData);
     }
   }

--- a/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.js
+++ b/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.js
@@ -229,7 +229,7 @@ function openIDB() {
 async function storeEncryptedLocalFile(id, file) {
   const key = await crypto.subtle.generateKey(
     { name: 'AES-GCM', length: 256 },
-    true,
+    false,
     ['encrypt', 'decrypt'],
   );
   const iv = crypto.getRandomValues(new Uint8Array(12));
@@ -238,12 +238,12 @@ async function storeEncryptedLocalFile(id, file) {
     key,
     await file.arrayBuffer(),
   );
-  const rawKey = await crypto.subtle.exportKey('raw', key);
 
+  const record = { ciphertext, iv, key, fileName: file.name, mimeType: file.type };
   const db = await openIDB();
   await new Promise((resolve, reject) => {
     const tx = db.transaction(IDB_STORE, 'readwrite');
-    tx.objectStore(IDB_STORE).put({ ciphertext, iv, rawKey, fileName: file.name, mimeType: file.type }, id);
+    tx.objectStore(IDB_STORE).put(record, id);
     tx.oncomplete = resolve;
     tx.onerror = ({ target: { error } }) => reject(error);
   });

--- a/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.js
+++ b/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.js
@@ -11,13 +11,11 @@ let loadScript;
 
 const EOLBrowserPage = 'https://acrobat.adobe.com/home/index-browser-eol.html';
 
-const MB100 = 104857600;
-const CHUNK_SIZE = 5 * 1024 * 1024;
-const CHUNK_THRESHOLD = 50 * 1024 * 1024;
-const ALL_FILES = ['.pdf', '.doc', '.docx', '.xml', '.ppt', '.pptx', '.xls', '.xlsx', '.rtf', '.txt', '.text', '.bmp', '.gif', '.jpeg', '.jpg', '.png', '.psd', '.tif', '.tiff'];
+const MB25 = 26214400;
+const ACCEPTED_FILES = ['.jpg', '.jpeg', '.png'];
 
 const LIMITS = {
-  'image-to-pdf': { maxFileSize: MB100, acceptedFiles: ALL_FILES, multipleFiles: true },
+  'image-to-pdf': { maxFileSize: MB25, acceptedFiles: ACCEPTED_FILES, multipleFiles: false },
 };
 
 const DC_ENV = ['www.adobe.com', 'sign.ing', 'edit.ing'].includes(window.location.hostname) ? 'prod' : 'stage';
@@ -70,23 +68,9 @@ const appEnvCookieMap = {
 };
 
 const MIME_TYPES = {
-  '.pdf': ['application/pdf'],
   '.jpg': ['image/jpeg'],
   '.jpeg': ['image/jpeg'],
   '.png': ['image/png'],
-  '.gif': ['image/gif'],
-  '.bmp': ['image/bmp'],
-  '.tif': ['image/tiff'],
-  '.tiff': ['image/tiff'],
-  '.doc': ['application/msword'],
-  '.docx': ['application/vnd.openxmlformats-officedocument.wordprocessingml.document'],
-  '.ppt': ['application/vnd.ms-powerpoint'],
-  '.pptx': ['application/vnd.openxmlformats-officedocument.presentationml.presentation'],
-  '.xls': ['application/vnd.ms-excel'],
-  '.xlsx': ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
-  '.txt': ['text/plain'],
-  '.rtf': ['application/rtf', 'text/rtf'],
-  '.xml': ['text/xml', 'application/xml'],
 };
 
 const ICONS = {
@@ -266,64 +250,11 @@ async function storeEncryptedLocalFile(id, file) {
   db.close();
 }
 
-async function storeEncryptedLocalFileChunked(id, file, { onChunkDone } = {}) {
-  const key = await crypto.subtle.generateKey(
-    { name: 'AES-GCM', length: 256 },
-    true,
-    ['encrypt', 'decrypt'],
-  );
-  const rawKey = await crypto.subtle.exportKey('raw', key);
-
-  const totalChunks = Math.ceil(file.size / CHUNK_SIZE);
-  const chunks = [];
-
-  for (let i = 0; i < totalChunks; i++) {
-    const start = i * CHUNK_SIZE;
-    const end = Math.min(start + CHUNK_SIZE, file.size);
-    const iv = crypto.getRandomValues(new Uint8Array(12));
-    const ciphertext = await crypto.subtle.encrypt(
-      { name: 'AES-GCM', iv },
-      key,
-      await file.slice(start, end).arrayBuffer(),
-    );
-    chunks.push({ ciphertext, iv });
-    onChunkDone?.(end - start, i);
-  }
-
-  const db = await openIDB();
-  await new Promise((resolve, reject) => {
-    const tx = db.transaction(IDB_STORE, 'readwrite');
-    tx.objectStore(IDB_STORE).put({ chunks, rawKey, fileName: file.name, mimeType: file.type, chunked: true }, id);
-    tx.oncomplete = resolve;
-    tx.onerror = ({ target: { error } }) => reject(error);
-  });
-  db.close();
-}
-
-async function encryptAndStore(fileList, { onProgress, onChunkComplete } = {}) {
-  const totalSize = fileList.reduce((s, f) => s + f.size, 0);
-  let processed = 0;
-
-  return Promise.all(
-    fileList.map(async (file) => {
-      const id = crypto.randomUUID();
-      if (file.size >= CHUNK_THRESHOLD) {
-        await storeEncryptedLocalFileChunked(id, file, {
-          onChunkDone: (chunkBytes, chunkIndex) => {
-            processed += chunkBytes;
-            onProgress?.(processed / totalSize);
-            onChunkComplete?.(id, chunkIndex, file);
-          },
-        });
-      } else {
-        await storeEncryptedLocalFile(id, file);
-        processed += file.size;
-        onProgress?.(processed / totalSize);
-        onChunkComplete?.(id, 0, file);
-      }
-      return id;
-    }),
-  );
+async function encryptAndStore(file, { onProgress } = {}) {
+  const id = crypto.randomUUID();
+  await storeEncryptedLocalFile(id, file);
+  onProgress?.(1);
+  return id;
 }
 
 function validateFiles(files, verb) {
@@ -659,54 +590,46 @@ export default async function init(element) {
   async function startUpload(files) {
     hideError();
 
+    const [file] = files;
     const filesData = {
       userAttempts,
-      size: files.reduce((s, f) => s + f.size, 0),
-      type: getFileType(files),
-      count: files.length,
-      uploadType: files.length > 1 ? 'mfu' : 'sfu',
+      size: file.size,
+      type: file.type,
+      count: 1,
+      uploadType: 'sfu',
     };
 
     isUploading = true;
     exitFlag = false;
     setCookie('UTS_Uploading', Date.now());
     handleAnalyticsEvent('job:uploading', filesData, false);
-    if (LIMITS[VERB]?.multipleFiles) handleAnalyticsEvent('job:multi-file-uploading', filesData, false);
 
     progressContainer.classList.remove('hide');
     ctaButton.classList.add('hide');
     setProgress(0, 'Encrypting…');
 
     try {
-      const ids = await encryptAndStore(files, {
+      const id = await encryptAndStore(file, {
         onProgress: (ratio) => setProgress(ratio, `Encrypting… ${Math.round(ratio * 100)}%`),
-        onChunkComplete: (id, chunkIndex, file) => {
-          window.analytics.sendAnalyticsToSplunk('job:chunk-uploaded', VERB, {
-            ...filesData,
-            assetId: id,
-            chunkNumber: chunkIndex,
-            chunkUploadAttempt: 1,
-          }, getSplunkEndpoint());
-        },
       });
 
-      setCookie('UTS_Uploaded', Date.now());
+      const uploadTimestamp = Date.now();
+      setCookie('UTS_Uploaded', uploadTimestamp);
       exitFlag = true;
       isUploading = false;
       incrementVerbKey(`${VERB}_attempts`);
       setUser();
 
       const uploadTime = getUploadTime();
-      const uploadedMetadata = { ...filesData, assetId: ids[0], uploadTime };
+      const uploadedMetadata = { ...filesData, assetId: id, uploadTime };
       handleAnalyticsEvent('job:uploaded', uploadedMetadata, false);
-      if (LIMITS[VERB]?.multipleFiles) handleAnalyticsEvent('job:multi-file-uploaded', uploadedMetadata, false);
 
       setProgress(1, 'Done');
 
       const redirectBase = window.mph?.['verb-widget-client-upload-redirect']
         || 'https://www.stage.adobe.com/acrobat/online.html';
-      const params = new URLSearchParams({ fileId: ids.join(',') });
-      const redirectUrl = `${redirectBase}?${params}`;
+      const [baseUrl, queryString] = redirectBase.split('?');
+      const redirectUrl = `${baseUrl}?UTS_Uploaded=${uploadTimestamp}&redirectTime=${Date.now()}&fileId=${id}${queryString ? `&${queryString}` : ''}`;
       handleAnalyticsEvent('job:redirect-success', { ...filesData, redirectUrl }, false);
       window.location.href = redirectUrl;
     } catch (err) {


### PR DESCRIPTION
## MWPW-197746: Add verb-widget-client-upload block

Resolves: [MWPW-197746](https://jira.corp.adobe.com/browse/MWPW-197746)

### Summary
Adds a new `verb-widget-client-upload` block — a client-side-upload variant of the
verb widget for the image-to-pdf flow. Instead of uploading to a backend, the file is
encrypted in the browser and stored locally, then the user is redirected to the
acrobat-online conversion page to complete the flow.

### What it does
- **Client-side encryption & storage** — generates an AES-GCM key at runtime via the
  Web Crypto API (random IV per file) and stores the encrypted file, key, and metadata
  in IndexedDB. No file bytes leave the browser from this block.
- **File validation** — accepts `.jpg` / `.jpeg` / `.png` up to 25 MB, single file.
- **Env-aware redirect** — on success, redirects to the acrobat-online page,
  preserving the existing query params (`clientConvert`, `UTS_Uploaded`, `redirectTime`,
  `fileId`) and appending `&force_meteriq=true`:
  - **prod** → `https://www.adobe.com/acrobat-online/jpg-to-pdf.html`
  - **stage** → `https://www.stage.adobe.com/acrobat-online/jpg-to-pdf.html`
- **Analytics** — emits job lifecycle events (uploading, uploaded, redirect-success)
  and error events to the Unity/Splunk logging endpoint.

### Files
- `acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.js` (new)
- `acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.css` (new)

### Test URLs
- main: https://stage--da-dc--adobecom.aem.page/acrobat/online/test/image-to-pdf-client-upload
- branch: https://mwpw-197746--da-dc--adobecom.aem.page/acrobat/online/test/image-to-pdf-client-upload

### Testing Notes

**Unit tests (added)**
`test/blocks/verb-widget-client-upload/verb-widget-client-upload.test.js` — 12 WTR tests, all passing:
- `validateFiles`: accepts valid jpg/png; rejects unknown verb, no files, multiple files,
  empty file, >25 MB, unsupported extension, and mismatched mime type.
- `storeEncryptedLocalFile`: stores an AES-GCM record (ciphertext, 12-byte iv, CryptoKey,
  fileName, mimeType) in IndexedDB and the ciphertext decrypts back to the original bytes.
- `encryptAndStore`: returns a valid UUID, persists a matching record, and produces a
  unique id + unique key + unique ciphertext per call (random IV verified).

Run: `npm run wtr:file -- ./test/blocks/verb-widget-client-upload/verb-widget-client-upload.test.js`
(Note: run on Node 20 — the WTR CLI fails on Node 26.)

**Manual — happy path**
1. Open the image-to-pdf page with the `verb-widget-client-upload` block.
2. Click "Select a file" and choose a valid image (`.jpg` / `.jpeg` / `.png`, <= 25 MB).
3. Verify the CTA becomes disabled and its label switches to "Processing…".
4. In DevTools -> Application -> IndexedDB, confirm a `dc-file-transfer` DB with an
   `encrypted-files` store holds a record keyed by a UUID.
5. Verify redirect to the correct base per env:
   - stage -> https://www.stage.adobe.com/acrobat-online/jpg-to-pdf.html
   - prod  -> https://www.adobe.com/acrobat-online/jpg-to-pdf.html
6. Confirm the redirect URL preserves `clientConvert=true`, `UTS_Uploaded`, `redirectTime`,
   `fileId=<uuid>`, and appends `&force_meteriq=true`.

**Manual — validation / error paths**
- Unsupported type (`.gif`, `.pdf`) -> inline error, CTA stays enabled, no redirect.
- File over 25 MB -> "too large" error, no upload.
- More than one file -> single-file error.
- Forced storage/encrypt failure -> generic error, CTA re-enables and restores "Select a file".

**Analytics**
- Confirm `job:uploading`, `job:uploaded`, `job:redirect-success` (and `error:*` on failures)
  fire to the Unity/Splunk logging endpoint.

**Regression / cleanup**
- `npm run lint` clean for both block files (JS + CSS).
- Removed dead progress-bar code (`hideProgress`, `setProgress`, `getFileType`, the
  `onProgress` callback, and the `.upload-progress*` elements + CSS); widget still renders
  with no leftover progress element in the DOM.

