### PR TITLE
[MWPW-202751]Make verb reskin independent of code update

### DIFF
--- a/acrobat/blocks/verb-widget/verb-widget.css
+++ b/acrobat/blocks/verb-widget/verb-widget.css
@@ -188,7 +188,8 @@
   width: var(--verb-widget-image-width);
 }
 
-.verb-image svg {
+.verb-image svg,
+.verb-image img {
   display: block;
   width: 100%;
   height: 100%;

--- a/acrobat/blocks/verb-widget/verb-widget.js
+++ b/acrobat/blocks/verb-widget/verb-widget.js
@@ -395,6 +395,18 @@ async function createSvgElement(iconName) {
   return svgElement.cloneNode(true);
 }
 
+// Returns an authored verb image when present, else null (falls back to coded SVG).
+// Supports either an <img> or an <a> link pointing at an .svg.
+function getAuthoredVerbIcon(element) {
+  const img = element.querySelector('img');
+  if (img) return img;
+  const svgLink = element.querySelector('a[href$=".svg"]');
+  if (svgLink) {
+    return createTag('img', { src: svgLink.getAttribute('href'), alt: '' });
+  }
+  return null;
+}
+
 // Initialize analytics functions as no-ops until loaded
 window.analytics = {
   verbAnalytics: () => {},
@@ -540,6 +552,8 @@ export default async function init(element) {
     widgetSubHeading = children[1].textContent;
     widgetMobSubHeading = children[2].textContent;
   }
+  // If a verb image is authored in the block, use it instead of the coded icon.
+  const authoredIcon = getAuthoredVerbIcon(element);
   let noOfFiles = null;
   let openFilePicker = true;
   const userAttempts = getVerbKey(`${VERB}_attempts`);
@@ -593,11 +607,12 @@ export default async function init(element) {
     ...(LIMITS[VERB]?.multipleFiles && { multiple: '' }),
   });
   const widgetImage = createTag('div', { class: 'verb-image' });
-  const verbIconName = `${VERB}`;
-  const verbImageSvg = await createSvgElement(verbIconName);
+  const verbImageSvg = authoredIcon || await createSvgElement(`${VERB}`);
   if (verbImageSvg) {
     verbImageSvg.classList.add('icon-verb-image');
-    verbImageSvg.setAttribute('alt', window.mph[`verb-widget-${VERB}-alt`] || VERB);
+    if (!verbImageSvg.getAttribute('alt')) {
+      verbImageSvg.setAttribute('alt', window.mph[`verb-widget-${VERB}-alt`] || VERB);
+    }
     widgetImage.appendChild(verbImageSvg);
   }
 

--- a/acrobat/blocks/verb-widget/verb-widget.js
+++ b/acrobat/blocks/verb-widget/verb-widget.js
@@ -395,8 +395,6 @@ async function createSvgElement(iconName) {
   return svgElement.cloneNode(true);
 }
 
-// Returns an authored verb image when present, else null (falls back to coded SVG).
-// Supports either an <img> or an <a> link pointing at an .svg.
 function getAuthoredVerbIcon(element) {
   const img = element.querySelector('img');
   if (img) return img;
@@ -552,7 +550,6 @@ export default async function init(element) {
     widgetSubHeading = children[1].textContent;
     widgetMobSubHeading = children[2].textContent;
   }
-  // If a verb image is authored in the block, use it instead of the coded icon.
   const authoredIcon = getAuthoredVerbIcon(element);
   let noOfFiles = null;
   let openFilePicker = true;


### PR DESCRIPTION
## Description
Lets authors override the verb-widget hero image from Document Authoring instead of relying solely on the coded SVG shipped in `icons/<verb>.svg`. When no image is authored, behavior is unchanged.

## Changes
- Add `getAuthoredVerbIcon(element)` helper that returns an authored image when present:
  - an `<img>` in the block, or
  - an `<a href="*.svg">` link (converted to an `<img>`).
  - returns `null` otherwise.
- Use the authored icon when available, falling back to the coded `createSvgElement(VERB)` icon: `authoredIcon || await createSvgElement(...)`.
- Preserve an authored `alt` attribute; only fall back to the `verb-widget-${VERB}-alt` placeholder / verb name when `alt` is empty.

## What the block supports (authoring reference)
This PR only touches the verb icon, but for context here is the full set of content the `verb-widget` block reads from authoring vs. placeholders:

- **Heading** — always read from the first row of the block.
- **Sub-copy (desktop & mobile)** — the block supports authoring copy directly instead of pulling from placeholders. To do this, author **three rows total**:
  - **Row 1** → Heading
  - **Row 2** → **Desktop** copy (`verb-widget-${VERB}-description`)
  - **Row 3** → **Mobile** copy (`verb-widget-${VERB}-mobile-description`)
  - The override only activates when there are **more than 2 rows**. With only a heading + one copy row, both desktop and mobile copy fall back to the placeholder values. Desktop and mobile copy are mutually exclusive at render time — the block inserts only one based on device (`isMobile`/`isTablet`), not via CSS media queries.
- **Verb icon** — **NEW in this PR:** an authored `<img>` or `<a href="*.svg">` overrides the coded `icons/<verb>.svg`. Falls back to the coded SVG when nothing is authored.

##Resolves
https://jira.corp.adobe.com/browse/MWPW-202751

## Test URLs
- Before: https://mwpw-554499--da-dc--adobecom.aem.page/acrobat/online/test/unity/file-compressor?unitylibs=stage
- After: https://mwpw-554499--da-dc--adobecom.aem.page/acrobat/online/test/unity/file-compressor?unitylibs=mwpw-202751

## Testing
**Verb icon (this PR):**
- Verb page with no authored image → coded SVG renders as before (regression check).
- Verb page with an authored `<img>` → authored image renders, authored `alt` preserved.
- Verb page with an authored `<a href="*.svg">` → link converted to `<img>` and renders.

**Authored copy (existing behavior — regression check, not changed in this PR):**
- Verb page with heading only (1 row) → desktop & mobile copy come from placeholders.
- Verb page with heading + 3 rows total → Row 2 renders as desktop copy on desktop; Row 3 renders as mobile copy on mobile/tablet.
- Confirm only one copy variant renders per device (desktop shows Row 2, mobile/tablet shows Row 3).
