### PR TITLE
[MWPW-203753]persist query param on stage only

### DIFF
--- a/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.js
+++ b/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.js
@@ -607,8 +607,8 @@ export default async function init(element) {
       const redirectBase = DC_ENV === 'prod'
         ? 'https://www.adobe.com/acrobat-online/image-to-pdf.html'
         : 'https://www.stage.adobe.com/acrobat-online/image-to-pdf.html';
-      const [baseUrl, queryString] = redirectBase.split('?');
-      const redirectUrl = `${baseUrl}?clientConvert=true&UTS_Uploaded=${uploadTimestamp}&redirectTime=${Date.now()}&fileId=${id}${queryString ? `&${queryString}` : ''}`;
+      const originalParams = DC_ENV === 'stage' ? `${window.location.search.slice(1)}&` : '';
+      const redirectUrl = `${redirectBase}?${originalParams}clientConvert=true&UTS_Uploaded=${uploadTimestamp}&redirectTime=${Date.now()}&fileId=${id}`;
       handleAnalyticsEvent('job:redirect-success', { ...filesData, redirectUrl }, false);
       window.location.href = redirectUrl;
     } catch (err) {


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
* Persist the query param when redirecting after upload on stage environment only

## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-203753](https://jira.corp.adobe.com/browse/MWPW-203753)

## Test URLs
<!-- List the URLs where the changes can be tested -->
- https://stage--da-dc--adobecom.aem.page/acrobat/online/test/image-to-pdf-client-upload?force_meteriq=true
- https://mwpw-203753--da-dc--adobecom.aem.page/acrobat/online/test/image-to-pdf-client-upload?force_meteriq=true
