### PR TITLE
MWPW-203232 [DC] M@S Fragment Prefetch

### DIFF
--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -431,7 +431,7 @@ replaceDotMedia(document);
 }());
 
 /*
- * M@S fragment prefetch 
+ * M@S fragment prefetch
  * Wired as Milo's config.decorateArea in loadPage below, so it preloads the
  * first section's M@S fragment before the block would fetch it and the fetch stops blocking
  * LCP. Logic is inlined here and reuses loadLink.

--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -431,10 +431,10 @@ replaceDotMedia(document);
 }());
 
 /*
- * [MWPW-203232] M@S (Merch at Scale) fragment prefetch — mirrors the CC implementation
- * (MWPW-203258). Wired as Milo's config.decorateArea in loadPage below, so it preloads the
+ * M@S fragment prefetch 
+ * Wired as Milo's config.decorateArea in loadPage below, so it preloads the
  * first section's M@S fragment before the block would fetch it and the fetch stops blocking
- * LCP. Logic is inlined here (no cross-origin merch.js/mas-geo.js import) and reuses loadLink.
+ * LCP. Logic is inlined here and reuses loadLink.
  * Best-effort: the browser reuses a preload only on a full-URL match, so a miss just wastes
  * one request; the block always fetches its own correct URL, so it can never show a wrong price.
  */
@@ -665,7 +665,7 @@ async function loadPage() {
     replacePlaceholdersWithImages(ietf, miloLibs);
   }
 
-  // [MWPW-203232] Preload first-section M@S fragments so their fetch stops blocking LCP. Wired
+  // Preload first-section M@S fragments so their fetch stops blocking LCP. Wired
   // as Milo's decorateArea: our initial call scans the authored document, and Milo re-invokes
   // it per loaded fragment (with { fragmentLink }), catching a marquee that MEP swaps in.
   const decorateArea = (area, options) => scanForMasLinks(area, options, getConfig());

--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -431,6 +431,150 @@ replaceDotMedia(document);
 }());
 
 /*
+ * [MWPW-203232] M@S (Merch at Scale) fragment prefetch — mirrors the CC implementation
+ * (MWPW-203258). Wired as Milo's config.decorateArea in loadPage below, so it preloads the
+ * first section's M@S fragment before the block would fetch it and the fetch stops blocking
+ * LCP. Logic is inlined here (no cross-origin merch.js/mas-geo.js import) and reuses loadLink.
+ * Best-effort: the browser reuses a preload only on a full-URL match, so a miss just wastes
+ * one request; the block always fetches its own correct URL, so it can never show a wrong price.
+ */
+const MAS_FRAGMENT_API = 'https://www.adobe.com/mas/io/fragment';
+const DEFAULT_MAS_FRAGMENT_API_KEY = 'wcms-commerce-ims-ro-user-milo';
+const MAS_LINK_SELECTOR = 'a[href*="mas.adobe.com/studio.html"]';
+
+// Kept in sync with GeoMap in Milo's blocks/merch/merch.js.
+const MAS_GEO_MAP = {
+  ar: 'AR_es',
+  be_en: 'BE_en',
+  be_fr: 'BE_fr',
+  be_nl: 'BE_nl',
+  br: 'BR_pt',
+  ca: 'CA_en',
+  ch_de: 'CH_de',
+  ch_fr: 'CH_fr',
+  ch_it: 'CH_it',
+  cl: 'CL_es',
+  co: 'CO_es',
+  la: 'DO_es',
+  mx: 'MX_es',
+  pe: 'PE_es',
+  africa: 'MU_en',
+  dk: 'DK_da',
+  de: 'DE_de',
+  ee: 'EE_et',
+  eg_ar: 'EG_ar',
+  eg_en: 'EG_en',
+  es: 'ES_es',
+  fr: 'FR_fr',
+  gr_el: 'GR_el',
+  gr_en: 'GR_en',
+  ie: 'IE_en',
+  il_he: 'IL_he',
+  it: 'IT_it',
+  lv: 'LV_lv',
+  lt: 'LT_lt',
+  lu_de: 'LU_de',
+  lu_en: 'LU_en',
+  lu_fr: 'LU_fr',
+  my_en: 'MY_en',
+  my_ms: 'MY_ms',
+  hu: 'HU_hu',
+  mt: 'MT_en',
+  mena_en: 'DZ_en',
+  mena_ar: 'DZ_ar',
+  nl: 'NL_nl',
+  no: 'NO_nb',
+  pl: 'PL_pl',
+  pt: 'PT_pt',
+  ro: 'RO_ro',
+  si: 'SI_sl',
+  sk: 'SK_sk',
+  fi: 'FI_fi',
+  se: 'SE_sv',
+  tr: 'TR_tr',
+  uk: 'GB_en',
+  at: 'AT_de',
+  cz: 'CZ_cs',
+  bg: 'BG_bg',
+  ru: 'RU_ru',
+  ua: 'UA_uk',
+  au: 'AU_en',
+  in_en: 'IN_en',
+  in_hi: 'IN_hi',
+  id_en: 'ID_en',
+  id_id: 'ID_id',
+  nz: 'NZ_en',
+  sa_ar: 'SA_ar',
+  sa_en: 'SA_en',
+  sg: 'SG_en',
+  cn: 'CN_zh',
+  tw: 'TW_zh',
+  hk_zh: 'HK_zh',
+  jp: 'JP_ja',
+  kr: 'KR_ko',
+  za: 'ZA_en',
+  ng: 'NG_en',
+  cr: 'CR_es',
+  ec: 'EC_es',
+  pr: 'US_es', // not a typo, should be US
+  gt: 'GT_es',
+  cis_en: 'TM_en',
+  cis_ru: 'TM_ru',
+  sea: 'SG_en',
+  th_en: 'TH_en',
+  th_th: 'TH_th',
+};
+
+// Kept in sync with EXTRA_MAS_LOCALES in Milo's blocks/merch/merch.js.
+const MAS_EXTRA_LOCALES = { pr: 'es_PR' };
+
+function getMasLocale(miloLocale) {
+  const geo = (miloLocale?.prefix || 'US_en').replace('/', '');
+  let [country = 'US', language = 'en'] = (MAS_GEO_MAP[geo] ?? geo).split('_', 2);
+  country = country.toUpperCase();
+  language = language.toLowerCase();
+  return { locale: MAS_EXTRA_LOCALES[geo] ?? `${language}_${country}`, country };
+}
+
+function preloadMasFragment(a, config) {
+  let url;
+  try {
+    // eslint-disable-next-line compat/compat
+    url = new URL(a.href);
+  } catch {
+    return;
+  }
+  if (url.hostname !== 'mas.adobe.com' || !url.pathname.endsWith('/studio.html')) return;
+  // eslint-disable-next-line compat/compat
+  const params = new URLSearchParams(url.hash.replace(/^#/, ''));
+  const fragment = params.get('fragment') || params.get('query');
+  if (!fragment) return;
+
+  const { locale, country } = getMasLocale(config?.locale);
+  const apiKey = config?.commerce?.['wcs-api-key'] ?? DEFAULT_MAS_FRAGMENT_API_KEY;
+  let endpoint = `${MAS_FRAGMENT_API}?id=${fragment}&api_key=${apiKey}&locale=${locale}`;
+  if (country && !locale.endsWith(`_${country}`)) endpoint += `&country=${country}`;
+
+  // loadLink dedups by href, so the same fragment authored on several variant links in
+  // section 0 (mobile/tablet/desktop) preloads once. Low priority so it never competes with
+  // the LCP image.
+  loadLink(endpoint, { rel: 'preload', as: 'fetch', crossorigin: 'anonymous', fetchpriority: 'low' });
+}
+
+function scanForMasLinks(area, options, config) {
+  const { fragmentLink } = options || {};
+  if (fragmentLink) {
+    if (fragmentLink.closest('.section')?.dataset.idx === '0') {
+      area?.querySelectorAll(MAS_LINK_SELECTOR).forEach((a) => preloadMasFragment(a, config));
+    }
+    return;
+  }
+  (area ?? document).querySelector('body > main > div')
+    ?.querySelectorAll(MAS_LINK_SELECTOR)
+    .forEach((a) => preloadMasFragment(a, config));
+}
+
+/*
  * ------------------------------------------------------------
  * Edit below at your own risk
  * ------------------------------------------------------------
@@ -511,7 +655,9 @@ async function loadPage() {
   }
 
   // Import base milo features and run them
-  const { loadArea, setConfig, loadLana, getMetadata, loadIms } = await import(`${miloLibs}/utils/utils.js`);
+  const {
+    loadArea, setConfig, loadLana, getMetadata, loadIms, getConfig,
+  } = await import(`${miloLibs}/utils/utils.js`);
   addLocale(ietf);
 
   if (getMetadata('commerce')) {
@@ -519,7 +665,12 @@ async function loadPage() {
     replacePlaceholdersWithImages(ietf, miloLibs);
   }
 
-  setConfig({ ...CONFIG, miloLibs });
+  // [MWPW-203232] Preload first-section M@S fragments so their fetch stops blocking LCP. Wired
+  // as Milo's decorateArea: our initial call scans the authored document, and Milo re-invokes
+  // it per loaded fragment (with { fragmentLink }), catching a marquee that MEP swaps in.
+  const decorateArea = (area, options) => scanForMasLinks(area, options, getConfig());
+  setConfig({ ...CONFIG, miloLibs, decorateArea });
+  decorateArea();
 
   window.addEventListener('IMS:Ready', async () => {
     const susiElems = document.querySelectorAll('a[href*="susi"]');


### PR DESCRIPTION
Resolves Jira: [MWPW-203232](https://jira.corp.adobe.com/browse/MWPW-203232)

## Description
Adds early `<link rel="preload">` for M@S fragment URLs found in the first (LCP) section, 
fired from `scripts.js` before the block hydrates. Warms the Akamai edge cache so the 
block's fetch resolves from CDN instead of a cold origin round-trip.

Test Url: https://mas-fragment-prefetch--da-dc--adobecom.aem.live/acrobat/acrobat-pro?mep=off 

In `/mas/libs/merch-cards.js`, please replace `credentials: "omit"` with `credentials: "same-origin"`.
<img width="3456" height="2234" alt="image" src="https://github.com/user-attachments/assets/4493984f-7533-4473-8629-f7bee400be4c" />

