### PR TITLE
MWPW-203763 Fix hover state

### DIFF
--- a/acrobat/blocks/verb-redesign-test/verb-redesign-test.css
+++ b/acrobat/blocks/verb-redesign-test/verb-redesign-test.css
@@ -1,5 +1,5 @@
 .verb-redesign-test {
-  --consonant-button-accent-action-bg: #3b63fb;
+  --consonant-button-accent-action-bg: #147AF3;
   --consonant-button-accent-action-bg-hover: #2d55e8;
 
   position: relative;
@@ -101,6 +101,7 @@
 
 .vm2-dropzone:hover {
   border-style: solid;
+  border-width: 2px;
   border-color: var(--consonant-button-accent-action-bg);
 }
 
@@ -856,6 +857,7 @@
 .verb-redesign-test.challenger1 .vm2-dropzone:hover,
 .verb-redesign-test.challenger2 .vm2-dropzone:hover {
   border-style: solid;
+  border-width: 2px;
   border-color: var(--consonant-button-accent-action-bg);
 }
 

--- a/acrobat/blocks/verb-redesign-test/verb-redesign-test.css
+++ b/acrobat/blocks/verb-redesign-test/verb-redesign-test.css
@@ -85,7 +85,7 @@
 
 .vm2-dropzone {
   width: 100%;
-  border: 1.5px dashed #adadad;
+  border: 2px dashed #adadad;
   border-radius: 16px;
   background: #fff;
   display: flex;
@@ -846,7 +846,7 @@
 }
 
 .verb-redesign-test.challenger2 .vm2-dropzone {
-  border: 1px dashed #747474;
+  border: 2px dashed #747474;
   border-radius: 15px;
   padding: 40px;
 }

--- a/acrobat/blocks/verb-redesign-test/verb-redesign-test.css
+++ b/acrobat/blocks/verb-redesign-test/verb-redesign-test.css
@@ -99,7 +99,11 @@
   box-sizing: border-box;
 }
 
-.vm2-dropzone:hover,
+.vm2-dropzone:hover {
+  border-style: solid;
+  border-color: var(--consonant-button-accent-action-bg);
+}
+
 .vm2-dropzone.dragging,
 .verb-redesign-test.dragging-block .vm2-dropzone {
   border-color: #1473E6;
@@ -844,6 +848,15 @@
   border: 1px dashed #747474;
   border-radius: 15px;
   padding: 40px;
+}
+
+/* Variant hover: overrides each challenger's own .vm2-dropzone border above.
+   Kept after those rules so the higher-specificity :hover wins and source order
+   stays ascending (stylelint no-descending-specificity). */
+.verb-redesign-test.challenger1 .vm2-dropzone:hover,
+.verb-redesign-test.challenger2 .vm2-dropzone:hover {
+  border-style: solid;
+  border-color: var(--consonant-button-accent-action-bg);
 }
 
 .verb-redesign-test.challenger2 .vm2-dropzone-media {


### PR DESCRIPTION
Resolves Jira: [MWPW-203763](https://jira.corp.adobe.com/browse/MWPW-203763)


## Summary
- Fixed hover state on `verb-redesign-test` drop zone to match Figma: solid 2px `#147AF3` border, no content shift on hover.
- Fixed CSS specificity bug where challenger rest-state rules were overriding the base hover rule, so hover never applied on variants.
- Aligned rest border width (2px) with hover width to prevent box-sizing shift.

## Test URLs
https://fix-hover-state--da-dc--adobecom.aem.page/acrobat/online/test/unity/verb-redesign-test-challenger1-jpg-to-pdf?unitylibs=verb-redesign2 
<img width="1728" height="1117" alt="Screenshot 2026-08-11 at 6 05 26 PM" src="https://github.com/user-attachments/assets/f4b0298c-f201-4f51-9799-ef0f978b4b1f" />

