### PR TITLE
[MWPW-204109] Support authored verb image in verb-widget without affecting copy

### DIFF
--- a/acrobat/blocks/verb-widget/verb-widget.js
+++ b/acrobat/blocks/verb-widget/verb-widget.js
@@ -549,14 +549,16 @@ export default async function init(element) {
 
   const children = element.querySelectorAll(':scope > div');
   const VERB = element.classList[1];
-  const widgetHeading = createTag('h1', { class: 'verb-heading' }, children[0].textContent);
+  const authoredIcon = getAuthoredVerbIcon(element);
+  const iconSource = element.querySelector('img, a[href$=".svg"]');
+  const rows = [...children].filter((row) => !iconSource || !row.contains(iconSource));
+  const widgetHeading = createTag('h1', { class: 'verb-heading' }, rows[0].textContent);
   let widgetSubHeading = window.mph[`verb-widget-${VERB}-description`];
   let widgetMobSubHeading = window.mph[`verb-widget-${VERB}-mobile-description`];
-  if (children.length > 2) {
-    widgetSubHeading = children[1].textContent;
-    widgetMobSubHeading = children[2].textContent;
+  if (rows.length > 2) {
+    widgetSubHeading = rows[1].textContent;
+    widgetMobSubHeading = rows[2].textContent;
   }
-  const authoredIcon = getAuthoredVerbIcon(element);
   let noOfFiles = null;
   let openFilePicker = true;
   const userAttempts = getVerbKey(`${VERB}_attempts`);

--- a/test/blocks/verb-widget/mocks/body-authored-icon.html
+++ b/test/blocks/verb-widget/mocks/body-authored-icon.html
@@ -1,0 +1,21 @@
+<main>
+  <div>
+    <div class="verb-widget compress-pdf">
+      <div>
+        <div>
+          <h1 id="compress-a-pdf">Compress a PDF</h1>
+        </div>
+      </div>
+      <div>
+        <div><a href="https://example.com/custom-compress.svg">custom-compress.svg</a></div>
+      </div>
+      <div>
+        <div>Authored desktop copy</div>
+      </div>
+      <div>
+        <div>Authored mobile copy</div>
+      </div>
+    </div>
+    <div class="unity workflow-acrobat"></div>
+  </div>
+</main>

--- a/test/blocks/verb-widget/verb-widget-authored-icon.test.js
+++ b/test/blocks/verb-widget/verb-widget-authored-icon.test.js
@@ -1,0 +1,58 @@
+/* eslint-disable compat/compat */
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { getConfig, setConfig } from 'https://main--milo--adobecom.aem.live/libs/utils/utils.js'; // eslint-disable-line import/no-unresolved, import/order
+
+const { default: init } = await import(
+  '../../../acrobat/blocks/verb-widget/verb-widget.js'
+);
+
+describe('verb-widget authored icon', () => {
+  let xhr;
+  let placeholders;
+
+  beforeEach(async () => {
+    sinon.stub(window, 'fetch');
+    window.fetch.callsFake((x) => {
+      if (x.endsWith('.svg')) {
+        return window.fetch.wrappedMethod.call(window, x);
+      }
+      return Promise.resolve();
+    });
+    const placeholdersText = await readFile({ path: './mocks/placeholders.json' });
+    placeholders = JSON.parse(placeholdersText);
+    window.mph = {};
+    placeholders.data.forEach((item) => {
+      window.mph[item.key] = item.value;
+    });
+    xhr = sinon.useFakeXMLHttpRequest();
+    document.head.innerHTML = await readFile({ path: './mocks/head.html' });
+    document.body.innerHTML = await readFile({ path: './mocks/body-authored-icon.html' });
+    window.adobeIMS = { isSignedInUser: () => false };
+  });
+
+  afterEach(() => {
+    xhr.restore();
+    sinon.restore();
+  });
+
+  it('uses the authored image and never treats the image row as copy', async () => {
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+    const block = document.body.querySelector('.verb-widget');
+    await init(block);
+
+    // The authored .svg link is rendered as the verb image (not the coded svg).
+    const authoredImg = document.querySelector('.verb-widget .verb-image img.icon-verb-image');
+    expect(authoredImg).to.exist;
+    expect(authoredImg.getAttribute('src')).to.contain('custom-compress.svg');
+
+    // The image row must not leak into the copy — even though it sits in row 2,
+    // the rendered copy is the authored copy text, not the image link/URL.
+    const copy = document.querySelector('.verb-widget .verb-copy');
+    expect(copy).to.exist;
+    expect(copy.textContent).to.contain('Authored desktop copy');
+    expect(copy.textContent).to.not.contain('.svg');
+  });
+});


### PR DESCRIPTION
Resolves: [MWPW-204109](https://jira.corp.adobe.com/browse/MWPW-204109)

## Summary
Lets authors add a custom verb image to the `verb-widget` block without it interfering with the copy. The copy override was row-count based, so an authored image counted as a copy row and could hijack the desktop/mobile copy slots. This filters the image row out before the copy is counted. Backward compatible — no image means no change.

## Changes
- Exclude the authored image row (`img` / `a[href$=".svg"]`) before deriving heading/copy.
- Add regression test for the authored-icon path (was previously untested).

## Test URLs
- https://stage--da-dc--adobecom.aem.page/acrobat/online/test/unity/file-compressor-copy
- https://mwpw-102938--da-dc--adobecom.aem.page/acrobat/online/test/unity/file-compressor-copy
