### PR TITLE
[MWPW-204240] Fix verb-redesign-test tooltip opacity to match verb-widget

### DIFF
--- a/acrobat/blocks/verb-redesign-test/verb-redesign-test.css
+++ b/acrobat/blocks/verb-redesign-test/verb-redesign-test.css
@@ -325,7 +325,7 @@
   outline: none;
 }
 
-.verb-redesign-test .info-icon:hover {
+.verb-redesign-test .info-icon:hover svg {
   opacity: 0.8;
 }
 


### PR DESCRIPTION
Scope the info-icon hover opacity to the SVG so the tooltip pseudo-elements stay fully opaque instead of being dimmed to 0.8.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-204240](https://jira.corp.adobe.com/browse/MWPW-204240)

## Test URLs
<!-- List the URLs where the changes can be tested -->
- https://stage--da-dc--adobecom.aem.page/acrobat/online/test/unity/verb-redesign-test-challenger2-jpg-to-pdf?unitylibs=stage
- https://mwpw-204240--da-dc--adobecom.aem.page/acrobat/online/test/unity/verb-redesign-test-challenger2-jpg-to-pdf?unitylibs=stage
