### PR TITLE
MWPW-204240 Set CTA font-family so button text uses Adobe Clean

### DIFF
--- a/acrobat/blocks/verb-redesign-test/verb-redesign-test.css
+++ b/acrobat/blocks/verb-redesign-test/verb-redesign-test.css
@@ -326,13 +326,13 @@
   outline: none;
 }
 
-.verb-redesign-test .info-icon:hover svg {
-  opacity: 0.8;
-}
-
 .verb-redesign-test .info-icon svg {
   width: 18px;
   height: 18px;
+}
+
+.verb-redesign-test .info-icon:hover svg {
+  opacity: 0.8;
 }
 
 .verb-redesign-test .milo-tooltip {

--- a/acrobat/blocks/verb-redesign-test/verb-redesign-test.css
+++ b/acrobat/blocks/verb-redesign-test/verb-redesign-test.css
@@ -162,6 +162,7 @@
   color: #fff;
   border: none;
   border-radius: 100px;
+  font-family: var(--body-font-family);
   font-size: 19px;
   font-weight: 700;
   line-height: 24px;


### PR DESCRIPTION
Buttons do not inherit font-family from the page, so .vm2-cta was falling back to the UA default (Arial). Set font-family on the CTA to match verb-widget.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-204240](https://jira.corp.adobe.com/browse/MWPW-204240

## Test URLs
<!-- List the URLs where the changes can be tested -->
- https://stage--da-dc--adobecom.aem.page/acrobat/online/test/unity/verb-redesign-test-challenger2-jpg-to-pdf?unitylibs=stage
- https://mwpw-204240--da-dc--adobecom.aem.page/acrobat/online/test/unity/verb-redesign-test-challenger2-jpg-to-pdf?unitylibs=stage
