### PR TITLE
Fix ph_fil banner: correct locale ietf from tl-PH to fil-PH

### DIFF
--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -228,7 +228,7 @@ const locales = {
   my_en: { ietf: 'en-MY', tk: 'pps7abe.css', base: '' },
   nz: { ietf: 'en-NZ', tk: 'pps7abe.css', base: '' },
   ph_en: { ietf: 'en-PH', tk: 'pps7abe.css', base: '' },
-  ph_fil: { ietf: 'tl-PH', tk: 'ict8rmp.css' },
+  ph_fil: { ietf: 'fil-PH', tk: 'ict8rmp.css' },
   sg: { ietf: 'en-SG', tk: 'pps7abe.css', base: '' },
   th_en: { ietf: 'en-TH', tk: 'pps7abe.css', base: '' },
   in_hi: { ietf: 'hi-IN', tk: 'aaa8deh.css' },


### PR DESCRIPTION
Jira: [MWPW-204601](https://jira.corp.adobe.com/browse/MWPW-204601)

**Fix ph_fil banner not showing on Acrobat**

Acrobat had `ph_fil: { ietf: 'tl-PH' }` while all other clients (CC, Milo, federal) use `fil-PH`. Milo's banner logic matches on this value against supported-markets (`lang: 'fil'`), so `tl` never matched → no banner. One-line fix to align with the rest.