### PR TITLE
[MWPW-204794]New study marquee variation for Avalon verbs

### DIFF
--- a/acrobat/blocks/study-marquee/study-marquee.css
+++ b/acrobat/blocks/study-marquee/study-marquee.css
@@ -783,9 +783,6 @@
 
 @media screen and (min-width: 1200px) {
   .study-marquee.avalon {
-    width: 100vw;
-    max-width: 100vw;
-    margin-inline: calc(50% - 50vw);
     padding-block: var(--spacing-xl);
     padding-inline: 0;
   }

--- a/acrobat/blocks/study-marquee/study-marquee.css
+++ b/acrobat/blocks/study-marquee/study-marquee.css
@@ -221,6 +221,7 @@
   color: #FFF;
   border: none;
   border-radius: 100px;
+  font-family: var(--body-font-family);
   font-size: 19px;
   line-height: 1.4;
   font-weight: 700;

--- a/acrobat/blocks/study-marquee/study-marquee.css
+++ b/acrobat/blocks/study-marquee/study-marquee.css
@@ -780,6 +780,114 @@
     color: var(--link-hover-color);
   }
 }
+
+@media screen and (min-width: 1200px) {
+  .study-marquee.avalon {
+    width: 100vw;
+    max-width: 100vw;
+    margin-inline: calc(50% - 50vw);
+    padding-block: var(--spacing-xl);
+    padding-inline: 0;
+  }
+
+  .study-marquee.avalon .study-marquee-row {
+    grid-template-columns: minmax(50%, 1fr) minmax(50%, 1fr);
+    align-items: center;
+    gap: 0;
+  }
+
+  .study-marquee.avalon .study-marquee-col-left {
+    box-sizing: border-box;
+    gap: 0;
+    padding-inline-end: 100px;
+  }
+
+  .study-marquee.avalon .study-marquee-header {
+    gap: 10px;
+    margin-bottom: var(--spacing-s);
+  }
+
+  .study-marquee.avalon .acrobat-icon {
+    width: var(--icon-size-m);
+    height: var(--icon-size-m);
+  }
+
+  .study-marquee.avalon .study-marquee-title {
+    font-size: 27px;
+    line-height: 1.25;
+    letter-spacing: -0.02em;
+  }
+
+  .study-marquee.avalon .study-marquee-heading {
+    font-family: var(--body-font-family);
+    font-size: var(--type-heading-xxl-size);
+    font-weight: 700;
+    line-height: var(--type-heading-xxl-lh);
+    letter-spacing: 0;
+    margin: 0 0 var(--spacing-xs);
+  }
+
+  .study-marquee.avalon .study-marquee-copy {
+    font-size: var(--type-body-xl-size);
+    font-weight: 400;
+    line-height: var(--type-body-xl-lh);
+    margin-bottom: 20px;
+  }
+
+  .study-marquee.avalon .study-marquee-dropzone {
+    margin-bottom: var(--spacing-s);
+    padding: 22px 10px;
+    gap: var(--spacing-xs);
+  }
+
+  .study-marquee.avalon .study-marquee-cta {
+    background-color: #3b63fb;
+    line-height: 24px;
+  }
+
+  .study-marquee.avalon .study-marquee-cta:hover {
+    background-color: #274dea;
+  }
+
+  .study-marquee.avalon .study-marquee-cta .upload-icon {
+    width: var(--icon-size-xs);
+    height: var(--icon-size-xs);
+  }
+
+  .study-marquee.avalon .study-marquee-drag {
+    line-height: 1.2;
+    letter-spacing: 0;
+  }
+
+  .study-marquee.avalon .study-marquee-footer {
+    flex-wrap: wrap;
+    row-gap: 10px;
+  }
+
+  .study-marquee.avalon .study-marquee-legal-extra {
+    flex: 0 0 100%;
+    width: 100%;
+  }
+
+  .study-marquee.avalon .study-marquee-media {
+    position: absolute;
+    width: 50vw;
+    height: 100%;
+    right: 0;
+    top: 0;
+    aspect-ratio: auto;
+  }
+
+  .study-marquee.avalon .study-marquee-media picture img,
+  .study-marquee.avalon .study-marquee-media video {
+    object-fit: cover;
+    object-position: center top;
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+}
+
 @media screen and (max-width: 600px) {
   .study-marquee-error {
     max-width: calc(100% - 32px);

--- a/acrobat/blocks/study-marquee/study-marquee.js
+++ b/acrobat/blocks/study-marquee/study-marquee.js
@@ -50,7 +50,10 @@ function createSvgElement(iconName) {
 
 const getCTA = (verb) => {
   const verbConfig = LIMITS[verb];
-  return window.mph?.[`verb-widget-cta-${verbConfig?.uploadType}`] || window.mph?.['verb-widget-cta'] || '';
+  return window.mph?.[`study-marquee-${verb}-upload-cta`]
+    || window.mph?.[`verb-widget-cta-${verbConfig?.uploadType}`]
+    || window.mph?.['verb-widget-cta']
+    || '';
 };
 
 function getEnv() {
@@ -290,7 +293,8 @@ export default async function init(element) {
 
   window.mph = window.mph || {};
   await loadPlaceholders(['study', 'verb-widget']);
-  const VERB = element.classList[1];
+  const isAvalon = element.classList.contains('avalon');
+  const VERB = element.classList[1] === 'avalon' ? element.classList[2] : element.classList[1];
   // Initialize analytics - track attempts for analytics data (no UI changes based on attempts)
   const userAttempts = getVerbKey(`${VERB}_attempts`);
   let noOfFiles = null;
@@ -505,23 +509,33 @@ export default async function init(element) {
     class: 'hide',
   }, tooltipContent);
   infoIcon.appendChild(tooltipText);
+  if (isAvalon) {
+    const extraLegalText = window.mph?.[`study-marquee-${VERB}-legal-extra`]
+      || window.mph?.['study-marquee-legal-extra'] || '';
+    if (extraLegalText) {
+      const extraLegal = createTag('p', { class: 'study-marquee-legal study-marquee-legal-extra' }, extraLegalText);
+      footer.append(extraLegal);
+    }
+  }
   footer.append(legalText, infoIcon);
   dropzone.append(ctaButton, dragText, fileLimitText);
   const leftColChildren = [
     header, headingEl, copy1, ...(copy2Text ? [copy2] : []), dropzone, fileInput, footer,
   ];
   leftCol.append(...leftColChildren);
+  let mediaWrapper = null;
   if (media) {
-    const mediaWrapper = createTag('div', { class: 'study-marquee-media' });
+    mediaWrapper = createTag('div', { class: 'study-marquee-media' });
     while (media.firstChild) {
       mediaWrapper.appendChild(media.firstChild);
     }
-    rightCol.appendChild(mediaWrapper);
+    if (!isAvalon) rightCol.appendChild(mediaWrapper);
   }
   row.append(leftCol, rightCol);
   container.appendChild(row);
   foreground.innerHTML = '';
   foreground.append(container);
+  if (isAvalon && mediaWrapper) element.append(mediaWrapper);
   element.append(errorState);
 
   function handleAnalyticsEvent(

--- a/test/blocks/study-marquee/mocks/placeholders.json
+++ b/test/blocks/study-marquee/mocks/placeholders.json
@@ -48,6 +48,10 @@
       "value": "By using this service, you agree to the Adobe Terms of Use and Privacy Policy."
     },
     {
+      "key": "study-marquee-legal-extra",
+      "value": "By clicking Generate, you confirm you are at least 13 years old (or older if required by the laws in your country)."
+    },
+    {
       "key": "verb-widget-terms-of-use",
       "value": "Terms of Use"
     },

--- a/test/blocks/study-marquee/study-marquee.test.js
+++ b/test/blocks/study-marquee/study-marquee.test.js
@@ -368,6 +368,121 @@ describe('study-marquee block', () => {
     expect(hrefs.some((h) => h && h.includes('privacy'))).to.be.true;
   });
 
+  it('avalon: renders extra legal text before the current legal text', async () => {
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+    const block = document.body.querySelector('.study-marquee');
+    block.classList.add('avalon');
+    await init(block);
+    await delay(100);
+    const footer = block.querySelector('.study-marquee-footer');
+    const extraLegal = footer.querySelector('.study-marquee-legal-extra');
+    const baseLegal = footer.querySelector('.study-marquee-legal:not(.study-marquee-legal-extra)');
+    expect(extraLegal).to.exist;
+    expect(extraLegal.textContent).to.contain('at least 13 years old');
+    // extra legal must come before the base legal text in DOM order
+    const position = extraLegal.compareDocumentPosition(baseLegal);
+    // eslint-disable-next-line no-bitwise
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).to.be.greaterThan(0);
+  });
+
+  it('avalon: cover media is a direct child of the block (hero-marquee media-cover)', async () => {
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+    const block = document.body.querySelector('.study-marquee');
+    block.classList.add('avalon');
+    await init(block);
+    await delay(100);
+    const media = block.querySelector('.study-marquee-media');
+    expect(media).to.exist;
+    expect(media.parentElement).to.equal(block);
+    expect(block.querySelector('.study-marquee-col-right .study-marquee-media')).to.not.exist;
+  });
+
+  it('base variation keeps media inside the right column', async () => {
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+    const block = document.body.querySelector('.study-marquee');
+    await init(block);
+    await delay(100);
+    expect(block.querySelector('.study-marquee-col-right .study-marquee-media')).to.exist;
+  });
+
+  it('base variation does not render the avalon extra legal text', async () => {
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+    const block = document.body.querySelector('.study-marquee');
+    await init(block);
+    await delay(100);
+    expect(block.querySelector('.study-marquee-legal-extra')).to.not.exist;
+  });
+
+  it('CTA text: verb-specific placeholder overrides the default', async () => {
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+    window.mph['study-marquee-quiz-maker-upload-cta'] = 'Make my quiz';
+    const block = document.body.querySelector('.study-marquee');
+    await init(block);
+    await delay(100);
+    const label = block.querySelector('.study-marquee-cta-label');
+    expect(label.textContent).to.equal('Make my quiz');
+    delete window.mph['study-marquee-quiz-maker-upload-cta'];
+  });
+
+  it('CTA text: falls back to the uploadType key when no verb-specific text', async () => {
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+    const block = document.body.querySelector('.study-marquee');
+    await init(block);
+    await delay(100);
+    const label = block.querySelector('.study-marquee-cta-label');
+    expect(label.textContent).to.equal(window.mph['verb-widget-cta-multifile-only']);
+  });
+
+  it('resolves the verb when the avalon token precedes the verb class', async () => {
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+    window.mph['study-marquee-quiz-maker-upload-cta'] = 'Quiz specific CTA';
+    const block = document.body.querySelector('.study-marquee');
+    // author order: study-marquee avalon quiz-maker (avalon becomes classList[1])
+    block.classList.remove('quiz-maker');
+    block.classList.add('avalon');
+    block.classList.add('quiz-maker');
+    await init(block);
+    await delay(100);
+    // VERB must still resolve to quiz-maker (classList[2]), proven by the verb-specific CTA
+    const label = block.querySelector('.study-marquee-cta-label');
+    expect(label.textContent).to.equal('Quiz specific CTA');
+    delete window.mph['study-marquee-quiz-maker-upload-cta'];
+  });
+
+  it('avalon: verb-specific extra legal key overrides the generic', async () => {
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+    window.mph['study-marquee-quiz-maker-legal-extra'] = 'Verb-specific legal line';
+    const block = document.body.querySelector('.study-marquee');
+    block.classList.add('avalon');
+    await init(block);
+    await delay(100);
+    const extra = block.querySelector('.study-marquee-legal-extra');
+    expect(extra).to.exist;
+    expect(extra.textContent).to.equal('Verb-specific legal line');
+    delete window.mph['study-marquee-quiz-maker-legal-extra'];
+  });
+
+  it('avalon: no extra legal element when no placeholder is authored', async () => {
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+    const saved = window.mph['study-marquee-legal-extra'];
+    delete window.mph['study-marquee-legal-extra'];
+    const block = document.body.querySelector('.study-marquee');
+    block.classList.add('avalon');
+    await init(block);
+    await delay(100);
+    expect(block.querySelector('.study-marquee-legal-extra')).to.not.exist;
+    window.mph['study-marquee-legal-extra'] = saved;
+  });
+
   it('upload button exists', async () => {
     const conf = getConfig();
     setConfig({ ...conf, locale: { prefix: '' } });


### PR DESCRIPTION
Resolves: [MWPW-204794](https://jira.corp.adobe.com/browse/MWPW-204794)

## Summary
Adds an `avalon` token variation to the `study-marquee` block — a desktop-only layout that mirrors Milo hero-marquee's **media-cover** style. Every change is scoped to `.study-marquee.avalon` (CSS) or an `isAvalon` flag (JS), so the base variation and all other blocks are unaffected.

## What's new (avalon token)
- **Media-cover layout** like hero-marquee: 50/50 split with the foreground asset full-bleed across the right half and content in the centered left half. The cover media is appended as a direct child of the block (hero's `.foreground-media` pattern), and the block is naturally full-width via the section (like hero's `width: 100%`) — no `100vw` breakout, so no horizontal-overflow risk.
- **Typography from Milo tokens**, matching hero-marquee: heading `--type-heading-xxl-*` (44/55), body `--type-body-xl-*` (22/33), lockup 27px / -0.02em with `--icon-size-m`, vertical padding `--spacing-xl`.
- **Copy vertical rhythm** per Figma: 24 / 16 / 20 (lockup → heading → body → dropzone).
- **Dropzone** per Figma: 22px padding, 16px gap, `#3b63fb` accent button, 24px icon, drag text line-height 1.2.
- **Authorable extra legal line** (avalon only): rendered above the base legal text; reads `study-marquee-{verb}-legal-extra` with a `study-marquee-legal-extra` fallback.
- **Verb-specific CTA text** (all variations, hero-marquee pattern): `study-marquee-{verb}-upload-cta` → `verb-widget-cta-{uploadType}` → `verb-widget-cta`.

## Notes
- Desktop-only: all avalon rules live in one `@media (min-width: 1200px)` block; no mobile/tablet changes.
- Base variation verified untouched via scoped selectors + dedicated tests.

## Test URLs
- Main: https://main--da-dc--adobecom.aem.page/acrobat/online/test/ruchika/generate-presentation
- Branch: https://mwpw-204794--da-dc--adobecom.aem.page/acrobat/online/test/ruchika/generate-presentation

## Testing
- study-marquee WTR suite: 32 passing (8 new — avalon media placement, extra legal + verb-specific/fallback, verb-specific CTA + fallback, resilient VERB parsing).
- ESLint + stylelint clean.
- Layout verified in headless Chrome: 50/50 split, media cover to the edge, no content overlap, no page overflow.

QE Testing Notes — MWPW-204794 (study-marquee "avalon" variation)

1. Verify the new avalon variation matches the Figma (desktop).
   Branch: https://mwpw-204794--da-dc--adobecom.aem.page/acrobat/online/test/ruchika/generate-presentation

2. Verify the existing (base) study-marquee still works as before — no regressions.
   Compare against main: https://main--da-dc--adobecom.aem.page/acrobat/online/quiz-maker



