### PR TITLE
[MWPW-204872]Fix cta font family for verb marquee block

### DIFF
--- a/acrobat/blocks/verb-marquee/verb-marquee.css
+++ b/acrobat/blocks/verb-marquee/verb-marquee.css
@@ -277,6 +277,7 @@
   color: #FFF;
   border: none;
   border-radius: 100px;
+  font-family: var(--body-font-family);
   font-size: 19px;
   line-height: 1.4;
   font-weight: 700;


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Fix cta font family for verb marquee block

## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-204872](https://jira.corp.adobe.com/browse/MWPW-204872)

## Test URLs
<!-- List the URLs where the changes can be tested -->
- https://main--da-dc--adobecom.aem.live/acrobat/online/ai-resume-builder
- https://verb-marquee-cta-font--da-dc--adobecom.aem.live/acrobat/online/ai-resume-builder
