### PR TITLE
[MWPW-204794]Inline the extra legal text for avalon

### DIFF
--- a/acrobat/blocks/study-marquee/study-marquee.css
+++ b/acrobat/blocks/study-marquee/study-marquee.css
@@ -858,13 +858,11 @@
   }
 
   .study-marquee.avalon .study-marquee-footer {
-    flex-wrap: wrap;
-    row-gap: 10px;
+    align-items: center;
   }
 
-  .study-marquee.avalon .study-marquee-legal-extra {
-    flex: 0 0 100%;
-    width: 100%;
+  .study-marquee.avalon .info-icon {
+    margin-top: 0;
   }
 
   .study-marquee.avalon .study-marquee-media {

--- a/acrobat/blocks/study-marquee/study-marquee.css
+++ b/acrobat/blocks/study-marquee/study-marquee.css
@@ -409,10 +409,6 @@
   outline: none;
 }
 
-.study-marquee .info-icon:hover {
-  opacity: 0.8;
-}
-
 .study-marquee .info-icon svg {
   width: 18px;
   height: 18px;

--- a/acrobat/blocks/study-marquee/study-marquee.js
+++ b/acrobat/blocks/study-marquee/study-marquee.js
@@ -513,8 +513,8 @@ export default async function init(element) {
     const extraLegalText = window.mph?.[`study-marquee-${VERB}-legal-extra`]
       || window.mph?.['study-marquee-legal-extra'] || '';
     if (extraLegalText) {
-      const extraLegal = createTag('p', { class: 'study-marquee-legal study-marquee-legal-extra' }, extraLegalText);
-      footer.append(extraLegal);
+      const extraLegal = createTag('span', { class: 'study-marquee-legal-extra' }, ` ${extraLegalText}`);
+      legalText.append(extraLegal);
     }
   }
   footer.append(legalText, infoIcon);

--- a/acrobat/blocks/verb-marquee/verb-marquee.css
+++ b/acrobat/blocks/verb-marquee/verb-marquee.css
@@ -523,10 +523,6 @@
   outline: none;
 }
 
-.verb-marquee .info-icon:hover {
-  opacity: 0.8;
-}
-
 .verb-marquee .info-icon svg {
   width: 18px;
   height: 18px;

--- a/test/blocks/study-marquee/study-marquee.test.js
+++ b/test/blocks/study-marquee/study-marquee.test.js
@@ -368,7 +368,7 @@ describe('study-marquee block', () => {
     expect(hrefs.some((h) => h && h.includes('privacy'))).to.be.true;
   });
 
-  it('avalon: renders extra legal text before the current legal text', async () => {
+  it('avalon: appends extra legal text inline as a continuation of the main legal paragraph', async () => {
     const conf = getConfig();
     setConfig({ ...conf, locale: { prefix: '' } });
     const block = document.body.querySelector('.study-marquee');
@@ -376,14 +376,13 @@ describe('study-marquee block', () => {
     await init(block);
     await delay(100);
     const footer = block.querySelector('.study-marquee-footer');
-    const extraLegal = footer.querySelector('.study-marquee-legal-extra');
     const baseLegal = footer.querySelector('.study-marquee-legal:not(.study-marquee-legal-extra)');
+    const extraLegal = footer.querySelector('.study-marquee-legal-extra');
     expect(extraLegal).to.exist;
     expect(extraLegal.textContent).to.contain('at least 13 years old');
-    // extra legal must come before the base legal text in DOM order
-    const position = extraLegal.compareDocumentPosition(baseLegal);
-    // eslint-disable-next-line no-bitwise
-    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).to.be.greaterThan(0);
+    // extra legal is an inline continuation within the main legal paragraph (not a separate block)
+    expect(extraLegal.tagName.toLowerCase()).to.equal('span');
+    expect(baseLegal.contains(extraLegal)).to.be.true;
   });
 
   it('avalon: cover media is a direct child of the block (hero-marquee media-cover)', async () => {
@@ -466,7 +465,7 @@ describe('study-marquee block', () => {
     await delay(100);
     const extra = block.querySelector('.study-marquee-legal-extra');
     expect(extra).to.exist;
-    expect(extra.textContent).to.equal('Verb-specific legal line');
+    expect(extra.textContent).to.contain('Verb-specific legal line');
     delete window.mph['study-marquee-quiz-maker-legal-extra'];
   });
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
* Inline the extra legal text for avalon (based on latest figma update)
* Make tooltip opaque both for study marquee and verb-marquee(used on ai resume builder)

## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-204794](https://jira.corp.adobe.com/browse/MWPW-204794)

## Test URLs
<!-- List the URLs where the changes can be tested -->
- Main: https://main--da-dc--adobecom.aem.page/acrobat/online/test/ruchika/generate-presentation
- Branch: https://mwpw-204794--da-dc--adobecom.aem.page/acrobat/online/test/ruchika/generate-presentation
