### PR TITLE
[MWPW-204909] Onboard gen-presentation-v2, interactive-reports, and stylize verbs

### DIFF
--- a/acrobat/blocks/study-marquee/AUTHORING-avalon.md
+++ b/acrobat/blocks/study-marquee/AUTHORING-avalon.md
@@ -1,0 +1,113 @@
+# Study Marquee (Avalon) — Authoring Guide
+
+The **Study Marquee** block is the split hero used on the AI study/creation verb pages (Stylize, Gen Presentation, Interactive Report, and the study makers). The **avalon** variant renders a two-column desktop layout — content on the left, a full-height cover image on the right — following Milo's `hero-marquee` `media-cover` pattern.
+
+> **Desktop-only variation:** The avalon **variation** is **desktop-specific — its styles apply only at ≥1200px** (see the block CSS). Designs were provided for desktop only, so this guide documents the desktop layout. It is not a separate block; below 1200px the study-marquee block falls back to its base responsive layout.
+
+> **Key concept:** Almost all the on-screen text is **not authored in the block**. The heading and the cover image are authored in the block; everything else (supporting copy, sub copy, upload button label, drag-and-drop text, file-size line, legal text, tooltip) is pulled from **placeholder keys** keyed by the verb. This guide lists every key you need to author in the placeholders sheet.
+
+## Block structure
+
+Author the block as a table. The **first cell names the block plus its options in parentheses**, in this order:
+
+```
+study-marquee (avalon, <verb-name>, <theme>)
+```
+
+- `avalon` — selects the avalon (split hero / media-cover) variant. Must come first.
+- `<verb-name>` — the verb, immediately after `avalon`. This determines which placeholder keys are read (e.g. `stylize`, `gen-presentation-v2`, `interactive-report`).
+- `<theme>` — optional theme that sets the text/link colors for a light or dark background: **`light`** or **`dark`**. Use `light` when the background is light (as in the sample).
+
+Example: `study-marquee (avalon, stylize, light)`
+
+## Rows
+
+| Row | Content | Required? |
+| --- | --- | --- |
+| **Row 1** | **Background** — a single cell with either a hex color (e.g. `#F0F0F0`) or a background image. | Optional |
+| **Row 2** | **Foreground** — two cells:<br>• _Left cell_: the **heading** (author as a heading, H1–H6) — and optionally the legal placeholder reference for documentation.<br>• _Right cell_: the **cover image** (media). | Required |
+
+> **How rows are detected:** the block treats the **last row** as the foreground and, when there is more than one row and the first row has content, the **first row** as the background. If you author a background, the foreground must be the second row.
+
+### Heading (foreground left cell)
+
+Author the title as a heading (H1–H6) directly in the block. This is the only body text authored in the block — the rest comes from placeholders below.
+
+### Cover image (foreground right cell)
+
+Add the image in the second cell of the foreground row. On desktop the avalon variant renders it as a full-height cover occupying the right half of the viewport; on smaller screens it stacks per the block's responsive rules.
+
+---
+
+## Placeholder keys
+
+Author these in the `study` placeholders sheet. Replace `<verb>` with the verb used in the block, e.g. `stylize`.
+
+> **Author all of these for each avalon verb.** The only optional ones are the verb **sub copy** and the **verb-specific legal** override — everything else must be authored.
+
+### Keys to author (per verb)
+
+| Placeholder key | What it controls | Required? |
+| --- | --- | --- |
+| `study-marquee-<verb>-copy` | Supporting copy shown under the heading. | Required |
+| `study-marquee-<verb>-sub-copy` | Second line of copy under the main copy. Only renders if authored. | Optional |
+| `study-marquee-<verb>-upload-cta` | Upload button label. | Required |
+| `study-widget-<verb>-dragndrop-text` | The "or drag and drop here" line under the button. | Required |
+| `study-widget-<verb>-file-limit` | The accepted-file-types / size line (e.g. "PDF, up to 100 MB"). | Required |
+
+### Legal text (avalon)
+
+| Placeholder key | What it controls | Required? |
+| --- | --- | --- |
+| `study-marquee-avalon-legal` | Legal text shared across all avalon pages. | Required |
+| `study-marquee-avalon-<verb>-legal` | Optional per-verb override of the avalon legal text. | Optional |
+
+The block uses the first one that is authored: `study-marquee-avalon-<verb>-legal` → `study-marquee-avalon-legal` → the base `study-marquee-legal-text`. The legal text is automatically hyperlinked (Terms of Use, Privacy Policy, Gen AI Guidelines) using the shared keys listed in the reference section below — author your legal copy so those label words appear in it.
+
+---
+
+## Sample authoring
+
+Matching the reference block `study-marquee (avalon, stylize, light)`:
+
+| study-marquee (avalon, stylize, light) ||
+| --- | --- |
+| #F0F0F0 ||
+| **Plain PDFs to polished docs. In minutes.**<br>`{{study-marquee-avalon-legal}}` | [cover image] |
+
+> **About `{{study-marquee-avalon-legal}}` in the block:** the legal text is resolved from the placeholder sheet (see the fallback order above), so authoring the token in the left cell is a documentation aid — the rendered legal always comes from the placeholder value, not from text typed into the block.
+
+### Corresponding placeholder values for the sample (verb = `stylize`)
+
+| Key | Example value |
+| --- | --- |
+| `study-marquee-stylize-copy` | Restyle and refresh your PDF with AI. |
+| `study-marquee-stylize-sub-copy` | Upload your PDF to get started. |
+| `study-marquee-stylize-upload-cta` | Select a file |
+| `study-widget-stylize-dragndrop-text` | or drag and drop a file |
+| `study-widget-stylize-file-limit` | PDF, up to 100 MB |
+| `study-marquee-avalon-legal` | By using this service, you agree to the Adobe Terms of Use, Generative AI User Guidelines, and acknowledge the Privacy Policy. |
+
+## Summary checklist
+
+- First cell reads `study-marquee (avalon, <verb>, light)` — `avalon` first, verb second.
+- Optional background row (hex color or image) before the foreground row.
+- Foreground row: heading in the left cell, cover image in the right cell.
+- Author the per-verb keys — `copy`, `upload-cta`, `study-widget-<verb>-dragndrop-text`, `study-widget-<verb>-file-limit`, and `study-marquee-avalon-legal` are **required**; `sub-copy` and `study-marquee-avalon-<verb>-legal` are optional.
+
+---
+
+## Reference — shared `verb-widget` keys (already authored, no action needed)
+
+These keys begin with `verb-widget-` and are **already authored as part of the verb-widget block**. They are shared across verb pages (not verb-specific) and are reused by study-marquee. **Nothing needs to be done here for avalon verbs** — they are listed for reference only.
+
+| Placeholder key | What it controls |
+| --- | --- |
+| `verb-widget-cta`, `verb-widget-cta-<uploadType>` | Fallback upload button labels used if `study-marquee-<verb>-upload-cta` is not authored. |
+| `verb-widget-terms-of-use` | Label linked to the Terms of Use URL inside the legal text. |
+| `verb-widget-privacy-policy` | Label linked to the Privacy Policy URL inside the legal text. |
+| `verb-widget-genai-guidelines` | Label linked to the Gen AI Guidelines URL (gen-AI verbs only). |
+| `verb-widget-terms-of-use-url` | Terms of Use URL (defaults to the locale's `/legal/terms.html`). |
+| `verb-widget-privacy-policy-url` | Privacy Policy URL (defaults to the locale's `/privacy/policy.html`). |
+| `verb-widget-genai-terms-url` | Gen AI Guidelines URL (defaults to the locale's Adobe Gen AI guidelines page). |
+| `verb-widget-tool-tip` | Text for the info (ⓘ) tooltip next to the legal text. |

--- a/acrobat/blocks/study-marquee/study-marquee.css
+++ b/acrobat/blocks/study-marquee/study-marquee.css
@@ -828,6 +828,15 @@
     margin-bottom: 20px;
   }
 
+  .study-marquee.avalon .study-marquee-copy-sub {
+    font-size: var(--type-body-xl-size);
+    font-weight: 400;
+    line-height: var(--type-body-xl-lh);
+    margin-top: 0;
+    margin-bottom: 20px;
+    opacity: 0.9;
+  }
+
   .study-marquee.avalon .study-marquee-dropzone {
     margin-bottom: var(--spacing-s);
     padding: 22px 10px;

--- a/acrobat/blocks/study-marquee/study-marquee.js
+++ b/acrobat/blocks/study-marquee/study-marquee.js
@@ -485,7 +485,13 @@ export default async function init(element) {
   const ppURL = window.mph?.['verb-widget-privacy-policy-url'] || `https://www.adobe.com${locale.prefix}/privacy/policy.html`;
   const touURL = window.mph?.['verb-widget-terms-of-use-url'] || `https://www.adobe.com${locale.prefix}/legal/terms.html`;
   const genAIurl = window.mph?.['verb-widget-genai-terms-url'] || `https://www.adobe.com${locale.prefix}/legal/licenses-terms/adobe-gen-ai-user-guidelines.html`;
-  const legalText = createTag('p', { class: 'study-marquee-legal' }, window.mph?.['study-marquee-legal-text'] || '');
+  const baseLegalText = window.mph?.['study-marquee-legal-text'] || '';
+  const legalTextContent = isAvalon
+    ? (window.mph?.[`study-marquee-avalon-${VERB}-legal`]
+      || window.mph?.['study-marquee-avalon-legal']
+      || baseLegalText)
+    : baseLegalText;
+  const legalText = createTag('p', { class: 'study-marquee-legal' }, legalTextContent);
   if (legalText.textContent) {
     const createLegalLink = (label, url) => `<a class="study-marquee-legal-url" target="_blank" href="${url}">${label}</a>`;
     const legalLinks = [
@@ -519,14 +525,6 @@ export default async function init(element) {
     class: 'hide',
   }, tooltipContent);
   infoIcon.appendChild(tooltipText);
-  if (isAvalon) {
-    const extraLegalText = window.mph?.[`study-marquee-${VERB}-legal-extra`]
-      || window.mph?.['study-marquee-legal-extra'] || '';
-    if (extraLegalText) {
-      const extraLegal = createTag('span', { class: 'study-marquee-legal-extra' }, ` ${extraLegalText}`);
-      legalText.append(extraLegal);
-    }
-  }
   footer.append(legalText, infoIcon);
   dropzone.append(ctaButton, dragText, fileLimitText);
   const leftColChildren = [

--- a/acrobat/blocks/study-marquee/study-marquee.js
+++ b/acrobat/blocks/study-marquee/study-marquee.js
@@ -38,6 +38,8 @@ const STUDY_GENAI_SINGLE = {
 };
 const group = (verbs, config) => verbs.reduce((acc, v) => { acc[v] = config; return acc; }, {});
 
+const SIGNED_IN_UPLOAD_VERBS = new Set(['gen-presentation-v2', 'interactive-report', 'stylize']);
+
 export const LIMITS = {
   ...group(['quiz-maker', 'flashcard-maker', 'mindmap-maker'], STUDY_GENAI),
   ...group(['gen-presentation-v2', 'interactive-report'], STUDY_GENAI_SINGLE),
@@ -804,6 +806,7 @@ export default async function init(element) {
   });
 
   async function checkSignedInUser() {
+    if (SIGNED_IN_UPLOAD_VERBS.has(VERB)) return;
     if (!window.adobeIMS?.isSignedInUser?.()) return;
     let accountType;
     try {

--- a/acrobat/blocks/study-marquee/study-marquee.js
+++ b/acrobat/blocks/study-marquee/study-marquee.js
@@ -22,17 +22,19 @@ const ICONS = {
 
 const MB100 = 104857600;
 const STUDY_FILES = ['.pdf', '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx', '.rtf', '.txt', '.text', '.vtt'];
+const STUDY_GENAI = {
+  maxFileSize: MB100,
+  acceptedFiles: STUDY_FILES,
+  maxNumFiles: 100,
+  multipleFiles: true,
+  uploadType: 'multifile-only',
+  genAI: true,
+};
 const STUDY_GENAI_SINGLE = {
   maxFileSize: MB100,
   acceptedFiles: STUDY_FILES,
   maxNumFiles: 1,
   genAI: true,
-};
-const STUDY_GENAI = {
-  ...STUDY_GENAI_SINGLE,
-  maxNumFiles: 100,
-  multipleFiles: true,
-  uploadType: 'multifile-only',
 };
 const group = (verbs, config) => verbs.reduce((acc, v) => { acc[v] = config; return acc; }, {});
 

--- a/acrobat/blocks/study-marquee/study-marquee.js
+++ b/acrobat/blocks/study-marquee/study-marquee.js
@@ -32,7 +32,10 @@ const STUDY_GENAI = {
 };
 const group = (verbs, config) => verbs.reduce((acc, v) => { acc[v] = config; return acc; }, {});
 
-export const LIMITS = { ...group(['quiz-maker', 'flashcard-maker', 'mindmap-maker'], STUDY_GENAI) };
+export const LIMITS = {
+  ...group(['quiz-maker', 'flashcard-maker', 'mindmap-maker', 'gen-presentation-v2', 'interactive-reports'], STUDY_GENAI),
+  stylize: { ...STUDY_GENAI, acceptedFiles: ['.pdf'] },
+};
 
 function createSvgElement(iconName) {
   const svgString = ICONS[iconName];

--- a/acrobat/blocks/study-marquee/study-marquee.js
+++ b/acrobat/blocks/study-marquee/study-marquee.js
@@ -22,19 +22,24 @@ const ICONS = {
 
 const MB100 = 104857600;
 const STUDY_FILES = ['.pdf', '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx', '.rtf', '.txt', '.text', '.vtt'];
-const STUDY_GENAI = {
+const STUDY_GENAI_SINGLE = {
   maxFileSize: MB100,
   acceptedFiles: STUDY_FILES,
+  maxNumFiles: 1,
+  genAI: true,
+};
+const STUDY_GENAI = {
+  ...STUDY_GENAI_SINGLE,
   maxNumFiles: 100,
   multipleFiles: true,
   uploadType: 'multifile-only',
-  genAI: true,
 };
 const group = (verbs, config) => verbs.reduce((acc, v) => { acc[v] = config; return acc; }, {});
 
 export const LIMITS = {
-  ...group(['quiz-maker', 'flashcard-maker', 'mindmap-maker', 'gen-presentation-v2', 'interactive-report'], STUDY_GENAI),
-  stylize: { ...STUDY_GENAI, acceptedFiles: ['.pdf'] },
+  ...group(['quiz-maker', 'flashcard-maker', 'mindmap-maker'], STUDY_GENAI),
+  ...group(['gen-presentation-v2', 'interactive-report'], STUDY_GENAI_SINGLE),
+  stylize: { ...STUDY_GENAI_SINGLE, acceptedFiles: ['.pdf'] },
 };
 
 function createSvgElement(iconName) {

--- a/acrobat/blocks/study-marquee/study-marquee.js
+++ b/acrobat/blocks/study-marquee/study-marquee.js
@@ -761,6 +761,7 @@ export default async function init(element) {
       error_file_same_type: 'error:file_same_type',
       error_password_protected: 'error:password_protected',
       error_acroform_not_supported: 'error:acroform_not_supported',
+      error_scanned_document: 'error:scanned_document',
       error_fetch_redirect_url: 'error:fetch_redirect_url',
       error_finalize_asset: 'error:finalize_asset',
       error_verify_page_count: 'error:verify_page_count',

--- a/acrobat/blocks/study-marquee/study-marquee.js
+++ b/acrobat/blocks/study-marquee/study-marquee.js
@@ -754,6 +754,8 @@ export default async function init(element) {
       error_duplicate_asset: 'error:duplicate_asset',
       warn_chunk_upload: 'warn:verb_upload_warn_chunk_upload',
       error_file_same_type: 'error:file_same_type',
+      error_password_protected: 'error:password_protected',
+      error_acroform_not_supported: 'error:acroform_not_supported',
       error_fetch_redirect_url: 'error:fetch_redirect_url',
       error_finalize_asset: 'error:finalize_asset',
       error_verify_page_count: 'error:verify_page_count',

--- a/acrobat/blocks/study-marquee/study-marquee.js
+++ b/acrobat/blocks/study-marquee/study-marquee.js
@@ -33,7 +33,7 @@ const STUDY_GENAI = {
 const group = (verbs, config) => verbs.reduce((acc, v) => { acc[v] = config; return acc; }, {});
 
 export const LIMITS = {
-  ...group(['quiz-maker', 'flashcard-maker', 'mindmap-maker', 'gen-presentation-v2', 'interactive-reports'], STUDY_GENAI),
+  ...group(['quiz-maker', 'flashcard-maker', 'mindmap-maker', 'gen-presentation-v2', 'interactive-report'], STUDY_GENAI),
   stylize: { ...STUDY_GENAI, acceptedFiles: ['.pdf'] },
 };
 

--- a/test/blocks/study-marquee/mocks/body-gen-presentation-v2.html
+++ b/test/blocks/study-marquee/mocks/body-gen-presentation-v2.html
@@ -1,0 +1,26 @@
+<main>
+  <div>
+    <div class="study-marquee avalon gen-presentation-v2">
+      <div>
+        <picture>
+          <source type="image/webp" srcset="./media_background.png" media="(min-width: 600px)">
+          <source type="image/webp" srcset="./media_background_mobile.png">
+          <img loading="lazy" alt="" src="./media_background.png" width="2000" height="1200">
+        </picture>
+      </div>
+      <div>
+        <div>
+          <h1 id="gen-presentation-v2">Generate Presentation</h1>
+        </div>
+        <div>
+          <picture>
+            <source type="image/webp" srcset="./media_foreground.png" media="(min-width: 600px)">
+            <source type="image/webp" srcset="./media_foreground_mobile.png">
+            <img loading="lazy" alt="" src="./media_foreground.png" width="800" height="600">
+          </picture>
+        </div>
+      </div>
+    </div>
+    <div class="unity workflow-acrobat"></div>
+  </div>
+</main>

--- a/test/blocks/study-marquee/mocks/body-interactive-report.html
+++ b/test/blocks/study-marquee/mocks/body-interactive-report.html
@@ -1,6 +1,6 @@
 <main>
   <div>
-    <div class="study-marquee avalon interactive-reports">
+    <div class="study-marquee avalon interactive-report">
       <div>
         <picture>
           <source type="image/webp" srcset="./media_background.png" media="(min-width: 600px)">
@@ -10,7 +10,7 @@
       </div>
       <div>
         <div>
-          <h1 id="interactive-reports">Interactive Reports</h1>
+          <h1 id="interactive-report">Interactive Reports</h1>
         </div>
         <div>
           <picture>

--- a/test/blocks/study-marquee/mocks/body-interactive-reports.html
+++ b/test/blocks/study-marquee/mocks/body-interactive-reports.html
@@ -1,0 +1,26 @@
+<main>
+  <div>
+    <div class="study-marquee avalon interactive-reports">
+      <div>
+        <picture>
+          <source type="image/webp" srcset="./media_background.png" media="(min-width: 600px)">
+          <source type="image/webp" srcset="./media_background_mobile.png">
+          <img loading="lazy" alt="" src="./media_background.png" width="2000" height="1200">
+        </picture>
+      </div>
+      <div>
+        <div>
+          <h1 id="interactive-reports">Interactive Reports</h1>
+        </div>
+        <div>
+          <picture>
+            <source type="image/webp" srcset="./media_foreground.png" media="(min-width: 600px)">
+            <source type="image/webp" srcset="./media_foreground_mobile.png">
+            <img loading="lazy" alt="" src="./media_foreground.png" width="800" height="600">
+          </picture>
+        </div>
+      </div>
+    </div>
+    <div class="unity workflow-acrobat"></div>
+  </div>
+</main>

--- a/test/blocks/study-marquee/mocks/body-stylize.html
+++ b/test/blocks/study-marquee/mocks/body-stylize.html
@@ -1,0 +1,26 @@
+<main>
+  <div>
+    <div class="study-marquee avalon stylize">
+      <div>
+        <picture>
+          <source type="image/webp" srcset="./media_background.png" media="(min-width: 600px)">
+          <source type="image/webp" srcset="./media_background_mobile.png">
+          <img loading="lazy" alt="" src="./media_background.png" width="2000" height="1200">
+        </picture>
+      </div>
+      <div>
+        <div>
+          <h1 id="stylize">Stylize PDF</h1>
+        </div>
+        <div>
+          <picture>
+            <source type="image/webp" srcset="./media_foreground.png" media="(min-width: 600px)">
+            <source type="image/webp" srcset="./media_foreground_mobile.png">
+            <img loading="lazy" alt="" src="./media_foreground.png" width="800" height="600">
+          </picture>
+        </div>
+      </div>
+    </div>
+    <div class="unity workflow-acrobat"></div>
+  </div>
+</main>

--- a/test/blocks/study-marquee/mocks/placeholders.json
+++ b/test/blocks/study-marquee/mocks/placeholders.json
@@ -24,23 +24,23 @@
       "value": "PDF, Word, PPT, XLS, TXT, up to 100 MB"
     },
     {
-      "key": "study-marquee-interactive-reports-copy",
+      "key": "study-marquee-interactive-report-copy",
       "value": "Transform your data into interactive reports with AI."
     },
     {
-      "key": "study-marquee-interactive-reports-mobile-copy",
+      "key": "study-marquee-interactive-report-mobile-copy",
       "value": "Build interactive reports from your files with AI."
     },
     {
-      "key": "study-marquee-interactive-reports-sub-copy",
+      "key": "study-marquee-interactive-report-sub-copy",
       "value": "Upload your files to get started."
     },
     {
-      "key": "study-widget-interactive-reports-dragndrop-text",
+      "key": "study-widget-interactive-report-dragndrop-text",
       "value": "or drag and drop files"
     },
     {
-      "key": "study-widget-interactive-reports-file-limit",
+      "key": "study-widget-interactive-report-file-limit",
       "value": "PDF, Word, PPT, XLS, TXT, up to 100 MB"
     },
     {

--- a/test/blocks/study-marquee/mocks/placeholders.json
+++ b/test/blocks/study-marquee/mocks/placeholders.json
@@ -112,6 +112,10 @@
       "value": "By clicking Generate, you confirm you are at least 13 years old (or older if required by the laws in your country)."
     },
     {
+      "key": "study-marquee-avalon-legal",
+      "value": "Avalon legal: by using this service, you agree to the Adobe Terms of Use and Privacy Policy."
+    },
+    {
       "key": "verb-widget-terms-of-use",
       "value": "Terms of Use"
     },

--- a/test/blocks/study-marquee/mocks/placeholders.json
+++ b/test/blocks/study-marquee/mocks/placeholders.json
@@ -1,8 +1,68 @@
 {
-  "total": 20,
+  "total": 35,
   "offset": 0,
-  "limit": 20,
+  "limit": 35,
   "data": [
+    {
+      "key": "study-marquee-gen-presentation-v2-copy",
+      "value": "Turn your documents into a polished presentation with AI."
+    },
+    {
+      "key": "study-marquee-gen-presentation-v2-mobile-copy",
+      "value": "Create a presentation from your files with AI."
+    },
+    {
+      "key": "study-marquee-gen-presentation-v2-sub-copy",
+      "value": "Upload your files to get started."
+    },
+    {
+      "key": "study-widget-gen-presentation-v2-dragndrop-text",
+      "value": "or drag and drop files"
+    },
+    {
+      "key": "study-widget-gen-presentation-v2-file-limit",
+      "value": "PDF, Word, PPT, XLS, TXT, up to 100 MB"
+    },
+    {
+      "key": "study-marquee-interactive-reports-copy",
+      "value": "Transform your data into interactive reports with AI."
+    },
+    {
+      "key": "study-marquee-interactive-reports-mobile-copy",
+      "value": "Build interactive reports from your files with AI."
+    },
+    {
+      "key": "study-marquee-interactive-reports-sub-copy",
+      "value": "Upload your files to get started."
+    },
+    {
+      "key": "study-widget-interactive-reports-dragndrop-text",
+      "value": "or drag and drop files"
+    },
+    {
+      "key": "study-widget-interactive-reports-file-limit",
+      "value": "PDF, Word, PPT, XLS, TXT, up to 100 MB"
+    },
+    {
+      "key": "study-marquee-stylize-copy",
+      "value": "Restyle and refresh your PDF with AI."
+    },
+    {
+      "key": "study-marquee-stylize-mobile-copy",
+      "value": "Give your PDF a new look with AI."
+    },
+    {
+      "key": "study-marquee-stylize-sub-copy",
+      "value": "Upload your PDF to get started."
+    },
+    {
+      "key": "study-widget-stylize-dragndrop-text",
+      "value": "or drag and drop a file"
+    },
+    {
+      "key": "study-widget-stylize-file-limit",
+      "value": "PDF, up to 100 MB"
+    },
     {
       "key": "verb-widget-cta",
       "value": "Select a file"

--- a/test/blocks/study-marquee/mocks/placeholders.json
+++ b/test/blocks/study-marquee/mocks/placeholders.json
@@ -17,7 +17,7 @@
     },
     {
       "key": "study-widget-gen-presentation-v2-dragndrop-text",
-      "value": "or drag and drop files"
+      "value": "or drag and drop a file"
     },
     {
       "key": "study-widget-gen-presentation-v2-file-limit",
@@ -37,7 +37,7 @@
     },
     {
       "key": "study-widget-interactive-report-dragndrop-text",
-      "value": "or drag and drop files"
+      "value": "or drag and drop a file"
     },
     {
       "key": "study-widget-interactive-report-file-limit",

--- a/test/blocks/study-marquee/study-marquee.test.js
+++ b/test/blocks/study-marquee/study-marquee.test.js
@@ -53,6 +53,57 @@ describe('study-marquee block', () => {
     expect(LIMITS['mindmap-maker'].genAI).to.be.true;
   });
 
+  it('exports LIMITS for gen-presentation-v2 and interactive-reports with study file types', () => {
+    expect(LIMITS).to.have.property('gen-presentation-v2');
+    expect(LIMITS).to.have.property('interactive-reports');
+    ['gen-presentation-v2', 'interactive-reports'].forEach((verb) => {
+      expect(LIMITS[verb].acceptedFiles).to.be.an('array');
+      expect(LIMITS[verb].acceptedFiles).to.deep.equal(LIMITS['flashcard-maker'].acceptedFiles);
+      expect(LIMITS[verb].maxFileSize).to.equal(104857600);
+      expect(LIMITS[verb].multipleFiles).to.be.true;
+      expect(LIMITS[verb].genAI).to.be.true;
+    });
+  });
+
+  it('exports LIMITS for stylize with PDF-only file type', () => {
+    expect(LIMITS).to.have.property('stylize');
+    expect(LIMITS.stylize.acceptedFiles).to.deep.equal(['.pdf']);
+    expect(LIMITS.stylize.maxFileSize).to.equal(104857600);
+    expect(LIMITS.stylize.multipleFiles).to.be.true;
+    expect(LIMITS.stylize.genAI).to.be.true;
+  });
+
+  it('init gen-presentation-v2 block', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/body-gen-presentation-v2.html' });
+    const block = document.body.querySelector('.study-marquee');
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+    await init(block);
+    expect(block.classList.contains('gen-presentation-v2')).to.be.true;
+    expect(document.querySelector('.study-marquee .study-marquee-dropzone')).to.exist;
+  });
+
+  it('init interactive-reports block', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/body-interactive-reports.html' });
+    const block = document.body.querySelector('.study-marquee');
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+    await init(block);
+    expect(block.classList.contains('interactive-reports')).to.be.true;
+    expect(document.querySelector('.study-marquee .study-marquee-dropzone')).to.exist;
+  });
+
+  it('init stylize block', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/body-stylize.html' });
+    const block = document.body.querySelector('.study-marquee');
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+    await init(block);
+    expect(block.classList.contains('stylize')).to.be.true;
+    expect(document.querySelector('.study-marquee .study-marquee-dropzone')).to.exist;
+    expect(document.querySelector('.study-marquee #file-upload').getAttribute('accept')).to.equal('.pdf');
+  });
+
   it('init study-marquee', async () => {
     const conf = getConfig();
     setConfig({ ...conf, locale: { prefix: '' } });

--- a/test/blocks/study-marquee/study-marquee.test.js
+++ b/test/blocks/study-marquee/study-marquee.test.js
@@ -469,21 +469,20 @@ describe('study-marquee block', () => {
     expect(hrefs.some((h) => h && h.includes('privacy'))).to.be.true;
   });
 
-  it('avalon: appends extra legal text inline as a continuation of the main legal paragraph', async () => {
+  it('avalon: loads the legal text from the avalon placeholder with decorated links', async () => {
     const conf = getConfig();
     setConfig({ ...conf, locale: { prefix: '' } });
     const block = document.body.querySelector('.study-marquee');
     block.classList.add('avalon');
     await init(block);
     await delay(100);
-    const footer = block.querySelector('.study-marquee-footer');
-    const baseLegal = footer.querySelector('.study-marquee-legal:not(.study-marquee-legal-extra)');
-    const extraLegal = footer.querySelector('.study-marquee-legal-extra');
-    expect(extraLegal).to.exist;
-    expect(extraLegal.textContent).to.contain('at least 13 years old');
-    // extra legal is an inline continuation within the main legal paragraph (not a separate block)
-    expect(extraLegal.tagName.toLowerCase()).to.equal('span');
-    expect(baseLegal.contains(extraLegal)).to.be.true;
+    const legal = block.querySelector('.study-marquee-footer .study-marquee-legal');
+    expect(legal).to.exist;
+    expect(legal.textContent).to.contain(window.mph['study-marquee-avalon-legal']);
+    // links are decorated the same way as the base legal text
+    const links = legal.querySelectorAll('a.study-marquee-legal-url');
+    expect(links.length).to.equal(2);
+    expect([...links].map((a) => a.textContent)).to.include.members(['Terms of Use', 'Privacy Policy']);
   });
 
   it('avalon: cover media is a direct child of the block (hero-marquee media-cover)', async () => {
@@ -508,13 +507,15 @@ describe('study-marquee block', () => {
     expect(block.querySelector('.study-marquee-col-right .study-marquee-media')).to.exist;
   });
 
-  it('base variation does not render the avalon extra legal text', async () => {
+  it('base variation loads the base legal text, not the avalon placeholder', async () => {
     const conf = getConfig();
     setConfig({ ...conf, locale: { prefix: '' } });
     const block = document.body.querySelector('.study-marquee');
     await init(block);
     await delay(100);
-    expect(block.querySelector('.study-marquee-legal-extra')).to.not.exist;
+    const legal = block.querySelector('.study-marquee-footer .study-marquee-legal');
+    expect(legal.textContent).to.not.contain('Avalon legal:');
+    expect(legal.textContent).to.contain('By using this service');
   });
 
   it('CTA text: verb-specific placeholder overrides the default', async () => {
@@ -556,31 +557,32 @@ describe('study-marquee block', () => {
     delete window.mph['study-marquee-quiz-maker-upload-cta'];
   });
 
-  it('avalon: verb-specific extra legal key overrides the generic', async () => {
+  it('avalon: verb-specific legal key overrides the generic avalon legal', async () => {
     const conf = getConfig();
     setConfig({ ...conf, locale: { prefix: '' } });
-    window.mph['study-marquee-quiz-maker-legal-extra'] = 'Verb-specific legal line';
+    window.mph['study-marquee-avalon-quiz-maker-legal'] = 'Verb-specific avalon legal line';
     const block = document.body.querySelector('.study-marquee');
     block.classList.add('avalon');
     await init(block);
     await delay(100);
-    const extra = block.querySelector('.study-marquee-legal-extra');
-    expect(extra).to.exist;
-    expect(extra.textContent).to.contain('Verb-specific legal line');
-    delete window.mph['study-marquee-quiz-maker-legal-extra'];
+    const legal = block.querySelector('.study-marquee-footer .study-marquee-legal');
+    expect(legal.textContent).to.contain('Verb-specific avalon legal line');
+    expect(legal.textContent).to.not.contain(window.mph['study-marquee-avalon-legal']);
+    delete window.mph['study-marquee-avalon-quiz-maker-legal'];
   });
 
-  it('avalon: no extra legal element when no placeholder is authored', async () => {
+  it('avalon: falls back to the base legal text when no avalon placeholder is authored', async () => {
     const conf = getConfig();
     setConfig({ ...conf, locale: { prefix: '' } });
-    const saved = window.mph['study-marquee-legal-extra'];
-    delete window.mph['study-marquee-legal-extra'];
+    const saved = window.mph['study-marquee-avalon-legal'];
+    delete window.mph['study-marquee-avalon-legal'];
     const block = document.body.querySelector('.study-marquee');
     block.classList.add('avalon');
     await init(block);
     await delay(100);
-    expect(block.querySelector('.study-marquee-legal-extra')).to.not.exist;
-    window.mph['study-marquee-legal-extra'] = saved;
+    const legal = block.querySelector('.study-marquee-footer .study-marquee-legal');
+    expect(legal.textContent).to.contain('By using this service');
+    window.mph['study-marquee-avalon-legal'] = saved;
   });
 
   it('upload button exists', async () => {

--- a/test/blocks/study-marquee/study-marquee.test.js
+++ b/test/blocks/study-marquee/study-marquee.test.js
@@ -163,6 +163,54 @@ describe('study-marquee block', () => {
     expect(window.lana.log.called).to.be.true;
   });
 
+  it('maps password-protected validation errors (single and multi) to analytics', async () => {
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+    const block = document.body.querySelector('.study-marquee');
+    await init(block);
+    await delay(100);
+
+    window.analytics = { verbAnalytics: sinon.spy(), sendAnalyticsToSplunk: sinon.spy() };
+
+    ['validation_error_password_protected', 'validation_error_password_protected_multi'].forEach((code) => {
+      block.dispatchEvent(new CustomEvent('unity:show-error-toast', { detail: { code, message: 'This file is password protected.', sendToSplunk: true } }));
+    });
+
+    expect(window.analytics.verbAnalytics.calledWith('error:password_protected')).to.be.true;
+    expect(window.analytics.sendAnalyticsToSplunk.calledWith('error_password_protected')).to.be.true;
+  });
+
+  it('maps acroform-not-supported validation errors (single and multi) to analytics', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/body-stylize.html' });
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+    const block = document.body.querySelector('.study-marquee');
+    await init(block);
+    await delay(100);
+
+    window.analytics = { verbAnalytics: sinon.spy(), sendAnalyticsToSplunk: sinon.spy() };
+
+    ['validation_error_acroform_not_supported', 'validation_error_acroform_not_supported_multi'].forEach((code) => {
+      block.dispatchEvent(new CustomEvent('unity:show-error-toast', { detail: { code, message: 'Forms are not supported.', sendToSplunk: true } }));
+    });
+
+    expect(window.analytics.verbAnalytics.calledWith('error:acroform_not_supported')).to.be.true;
+    expect(window.analytics.sendAnalyticsToSplunk.calledWith('error_acroform_not_supported')).to.be.true;
+  });
+
+  it('displays the error toast message for the new validation error codes', async () => {
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+    const block = document.body.querySelector('.study-marquee');
+    await init(block);
+    await delay(100);
+    window.analytics = { verbAnalytics: sinon.spy(), sendAnalyticsToSplunk: sinon.spy() };
+    block.dispatchEvent(new CustomEvent('unity:show-error-toast', { detail: { code: 'validation_error_password_protected', message: 'This file is password protected.', sendToSplunk: false } }));
+    const errorState = block.querySelector('.error');
+    expect(errorState.classList.contains('hide')).to.be.false;
+    expect(block.querySelector('.study-marquee-error-text').textContent).to.equal('This file is password protected.');
+  });
+
   it('error close button hides error state', async () => {
     const conf = getConfig();
     setConfig({ ...conf, locale: { prefix: '' } });

--- a/test/blocks/study-marquee/study-marquee.test.js
+++ b/test/blocks/study-marquee/study-marquee.test.js
@@ -53,23 +53,25 @@ describe('study-marquee block', () => {
     expect(LIMITS['mindmap-maker'].genAI).to.be.true;
   });
 
-  it('exports LIMITS for gen-presentation-v2 and interactive-report with study file types', () => {
+  it('exports LIMITS for gen-presentation-v2 and interactive-report as single-file study verbs', () => {
     expect(LIMITS).to.have.property('gen-presentation-v2');
     expect(LIMITS).to.have.property('interactive-report');
     ['gen-presentation-v2', 'interactive-report'].forEach((verb) => {
       expect(LIMITS[verb].acceptedFiles).to.be.an('array');
       expect(LIMITS[verb].acceptedFiles).to.deep.equal(LIMITS['flashcard-maker'].acceptedFiles);
       expect(LIMITS[verb].maxFileSize).to.equal(104857600);
-      expect(LIMITS[verb].multipleFiles).to.be.true;
+      expect(LIMITS[verb].maxNumFiles).to.equal(1);
+      expect(LIMITS[verb].multipleFiles).to.not.be.ok;
       expect(LIMITS[verb].genAI).to.be.true;
     });
   });
 
-  it('exports LIMITS for stylize with PDF-only file type', () => {
+  it('exports LIMITS for stylize as a single-file PDF-only verb', () => {
     expect(LIMITS).to.have.property('stylize');
     expect(LIMITS.stylize.acceptedFiles).to.deep.equal(['.pdf']);
     expect(LIMITS.stylize.maxFileSize).to.equal(104857600);
-    expect(LIMITS.stylize.multipleFiles).to.be.true;
+    expect(LIMITS.stylize.maxNumFiles).to.equal(1);
+    expect(LIMITS.stylize.multipleFiles).to.not.be.ok;
     expect(LIMITS.stylize.genAI).to.be.true;
   });
 

--- a/test/blocks/study-marquee/study-marquee.test.js
+++ b/test/blocks/study-marquee/study-marquee.test.js
@@ -53,10 +53,10 @@ describe('study-marquee block', () => {
     expect(LIMITS['mindmap-maker'].genAI).to.be.true;
   });
 
-  it('exports LIMITS for gen-presentation-v2 and interactive-reports with study file types', () => {
+  it('exports LIMITS for gen-presentation-v2 and interactive-report with study file types', () => {
     expect(LIMITS).to.have.property('gen-presentation-v2');
-    expect(LIMITS).to.have.property('interactive-reports');
-    ['gen-presentation-v2', 'interactive-reports'].forEach((verb) => {
+    expect(LIMITS).to.have.property('interactive-report');
+    ['gen-presentation-v2', 'interactive-report'].forEach((verb) => {
       expect(LIMITS[verb].acceptedFiles).to.be.an('array');
       expect(LIMITS[verb].acceptedFiles).to.deep.equal(LIMITS['flashcard-maker'].acceptedFiles);
       expect(LIMITS[verb].maxFileSize).to.equal(104857600);
@@ -83,13 +83,13 @@ describe('study-marquee block', () => {
     expect(document.querySelector('.study-marquee .study-marquee-dropzone')).to.exist;
   });
 
-  it('init interactive-reports block', async () => {
-    document.body.innerHTML = await readFile({ path: './mocks/body-interactive-reports.html' });
+  it('init interactive-report block', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/body-interactive-report.html' });
     const block = document.body.querySelector('.study-marquee');
     const conf = getConfig();
     setConfig({ ...conf, locale: { prefix: '' } });
     await init(block);
-    expect(block.classList.contains('interactive-reports')).to.be.true;
+    expect(block.classList.contains('interactive-report')).to.be.true;
     expect(document.querySelector('.study-marquee .study-marquee-dropzone')).to.exist;
   });
 

--- a/test/blocks/study-marquee/study-marquee.test.js
+++ b/test/blocks/study-marquee/study-marquee.test.js
@@ -200,6 +200,24 @@ describe('study-marquee block', () => {
     expect(window.analytics.sendAnalyticsToSplunk.calledWith('error_acroform_not_supported')).to.be.true;
   });
 
+  it('maps scanned-document validation errors (single and multi) to analytics', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/body-stylize.html' });
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+    const block = document.body.querySelector('.study-marquee');
+    await init(block);
+    await delay(100);
+
+    window.analytics = { verbAnalytics: sinon.spy(), sendAnalyticsToSplunk: sinon.spy() };
+
+    ['validation_error_scanned_document', 'validation_error_scanned_document_multi'].forEach((code) => {
+      block.dispatchEvent(new CustomEvent('unity:show-error-toast', { detail: { code, message: 'Scanned documents are not supported.', sendToSplunk: true } }));
+    });
+
+    expect(window.analytics.verbAnalytics.calledWith('error:scanned_document')).to.be.true;
+    expect(window.analytics.sendAnalyticsToSplunk.calledWith('error_scanned_document')).to.be.true;
+  });
+
   it('displays the error toast message for the new validation error codes', async () => {
     const conf = getConfig();
     setConfig({ ...conf, locale: { prefix: '' } });


### PR DESCRIPTION
## Summary
Onboards three new verbs onto the study-marquee block (avalon variation):
- `gen-presentation-v2` & `interactive-reports` — STUDY_GENAI config (file types match flashcard-maker)
- `stylize` — PDF-only

Also handles the two new PDF validation errors Unity's avalon workflow dispatches for these verbs:
- Integrity check → `validation_error_password_protected` / `_multi`
- AcroForm check → `validation_error_acroform_not_supported` / `_multi`
- Scanned pdf check -> `validation_error_scanned_document` / ` _multi`

Both (single + multi) are mapped to analytics events in the `unity:show-error-toast` handler; the toast display already renders the Unity-provided message.

Resolves: [MWPW-204909](https://jira.corp.adobe.com/browse/MWPW-204909)

## Changes
- Add the three verbs to `LIMITS` in `acrobat/blocks/study-marquee/study-marquee.js`
- Add `error_password_protected` , `error_acroform_not_supported` and `error_scanned_document` to the error analytics map
- Add test mock HTML (avalon variation) and unit tests for each verb
- Add placeholder keys (copy / drag-drop / file-limit) per verb

## Test URLs
- https://mwpw-204909--da-dc--adobecom.aem.page/acrobat/online/test/ruchika/interactive-report?unitylibs=avalon
- https://mwpw-204909--da-dc--adobecom.aem.page/acrobat/online/test/ruchika/generate-presentation?unitylibs=avalon
- https://mwpw-204909--da-dc--adobecom.aem.page/acrobat/online/test/ruchika/stylize?unitylibs=avalon

## Test plan
- [x] `npm run wtr:file -- ./test/blocks/study-marquee/study-marquee.test.js` passes (40/40)
- [x] `npm test` full suite passes
- [x] Lint clean

Testing Notes: 
- Unity integration is not implemented on stage on unity BE and product side yet so end to end flow will not work yet. Please test all the client side validation till then.
- Also make sure pages render as per figma https://www.figma.com/design/CCx7N5MlPBg9cfnK5C9gEM/MLG---Stylize--Gen-Pres--Interactive-Reports?node-id=0-1&p=f&m=dev
- Verify existing student space verbs on feature branch no impact on their UI or feature.

