### PR TITLE
MWPW-203032: make focus border visible

### DIFF
--- a/acrobat/blocks/study-marquee/study-marquee.css
+++ b/acrobat/blocks/study-marquee/study-marquee.css
@@ -563,7 +563,11 @@
   display: block;
   background: none;
   border: none;
-  outline: none;
+}
+
+.study-marquee-errorBtn:focus-visible {
+  box-shadow: 0 0 0 2px var(--consonant-color-white, #fff);
+  border-radius: 2px;
 }
 
 .study-marquee-errorIcon {

--- a/acrobat/blocks/study-marquee/study-marquee.css
+++ b/acrobat/blocks/study-marquee/study-marquee.css
@@ -563,9 +563,10 @@
   display: block;
   background: none;
   border: none;
+  outline: none;
 }
 
-.study-marquee-errorBtn:focus-visible {
+.study-marquee-errorBtn:focus {
   box-shadow: 0 0 0 2px var(--consonant-color-white, #fff);
   border-radius: 2px;
 }

--- a/acrobat/blocks/verb-marquee/verb-marquee.css
+++ b/acrobat/blocks/verb-marquee/verb-marquee.css
@@ -679,9 +679,10 @@
   display: block;
   background: none;
   border: none;
+  outline: none;
 }
 
-.verb-marquee-errorBtn:focus-visible {
+.verb-marquee-errorBtn:focus {
   box-shadow: 0 0 0 2px var(--consonant-color-white, #fff);
   border-radius: 2px;
 }

--- a/acrobat/blocks/verb-marquee/verb-marquee.css
+++ b/acrobat/blocks/verb-marquee/verb-marquee.css
@@ -679,7 +679,11 @@
   display: block;
   background: none;
   border: none;
-  outline: none;
+}
+
+.verb-marquee-errorBtn:focus-visible {
+  box-shadow: 0 0 0 2px var(--consonant-color-white, #fff);
+  border-radius: 2px;
 }
 
 .verb-marquee-errorIcon {

--- a/acrobat/blocks/verb-redesign-test/verb-redesign-test.css
+++ b/acrobat/blocks/verb-redesign-test/verb-redesign-test.css
@@ -465,6 +465,11 @@
   outline: none;
 }
 
+.vm2-error-btn:focus {
+  box-shadow: 0 0 0 2px var(--consonant-color-white, #fff);
+  border-radius: 2px;
+}
+
 .vm2-error-icon {
   align-self: self-start;
   width: 18px;

--- a/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.css
+++ b/acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.css
@@ -343,6 +343,11 @@ html[dir="rtl"] .verb-cta .upload-icon {
   outline: none;
 }
 
+.verb-errorBtn:focus {
+  box-shadow: 0 0 0 2px var(--consonant-color-white);
+  border-radius: 2px;
+}
+
 .verb-errorIcon {
   align-self: self-start;
   width: 18px;

--- a/acrobat/blocks/verb-widget/verb-widget.css
+++ b/acrobat/blocks/verb-widget/verb-widget.css
@@ -418,7 +418,11 @@ html[dir="rtl"] .verb-cta .upload-icon {
   display: block;
   background: none;
   border: none;
-  outline: none;
+}
+
+.verb-errorBtn:focus-visible {
+  box-shadow: 0 0 0 2px var(--consonant-color-white);
+  border-radius: 2px;
 }
 
 .verb-errorIcon {

--- a/acrobat/blocks/verb-widget/verb-widget.css
+++ b/acrobat/blocks/verb-widget/verb-widget.css
@@ -418,9 +418,10 @@ html[dir="rtl"] .verb-cta .upload-icon {
   display: block;
   background: none;
   border: none;
+  outline: none;
 }
 
-.verb-errorBtn:focus-visible {
+.verb-errorBtn:focus {
   box-shadow: 0 0 0 2px var(--consonant-color-white);
   border-radius: 2px;
 }


### PR DESCRIPTION
## Description
make focus border visible for error button

## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-203032](https://jira.corp.adobe.com/browse/MWPW-203032)

## Test URLs
<!-- List the URLs where the changes can be tested -->
- https://main--da-dc--adobecom.aem.live/acrobat/online/compress-pdf
- https://mwpw-203032--da-dc--adobecom.aem.live/acrobat/online/compress-pdf

- https://main--da-dc--adobecom.aem.live/acrobat/online/flashcard-maker
- https://mwpw-203032--da-dc--adobecom.aem.live/acrobat/online/flashcard-maker
