### PR TITLE
[DOTCOM-195104]Handle font-weight for avalon variant of study-marquee for mobile/tablet

### DIFF
--- a/acrobat/blocks/study-marquee/study-marquee.css
+++ b/acrobat/blocks/study-marquee/study-marquee.css
@@ -777,6 +777,16 @@
   }
 }
 
+@media screen and (max-width: 1199px) {
+  .study-marquee.avalon .study-marquee-heading {
+    font-weight: 700;
+  }
+
+  .study-marquee.avalon .study-marquee-copy-sub {
+    font-weight: 400;
+  }
+}
+
 @media screen and (min-width: 1200px) {
   .study-marquee.avalon {
     padding-block: var(--spacing-xl);

--- a/acrobat/blocks/study-marquee/study-marquee.css
+++ b/acrobat/blocks/study-marquee/study-marquee.css
@@ -779,7 +779,11 @@
 
 @media screen and (max-width: 1199px) {
   .study-marquee.avalon .study-marquee-heading {
+    font-family: var(--body-font-family);
+    font-size: var(--type-heading-xxl-size);
     font-weight: 700;
+    line-height: var(--type-heading-xxl-lh);
+    letter-spacing: 0;
   }
 
   .study-marquee.avalon .study-marquee-copy-sub {


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Handle font-weight for avalon variant of study-marquee for mobile/tablet

## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [DOTCOM-195104](https://jira.corp.adobe.com/browse/DOTCOM-195104)

## Test URLs
<!-- List the URLs where the changes can be tested -->
- https://stage--da-dc--adobecom.aem.page/acrobat/campaign/generate-presentation
- https://avalon-font--da-dc--adobecom.aem.page/acrobat/campaign/generate-presentation
