### PR TITLE
[MWPW-205598]Update supported file type for gen presentation and interactive report verbs

### DIFF
--- a/acrobat/blocks/study-marquee/study-marquee.js
+++ b/acrobat/blocks/study-marquee/study-marquee.js
@@ -581,13 +581,17 @@ export default async function init(element) {
 
   function handleUploadedEvent(data, attempts, cookieExp, canSendDataToSplunk) {
     exitFlag = true;
-    setTimeout(() => {
-      window.dispatchEvent(redirectReady);
-      window.lana?.log(
-        'Adobe Analytics done callback failed to trigger, 3 second timeout dispatched event.',
-        { sampleRate: 1, tags: 'DC_Milo,Project Unity (DC)', severity: 'warning' },
-      );
-    }, 3000);
+    if (LIMITS[VERB]?.noRedirectTimeout ?? true) {
+          window.dispatchEvent(redirectReady);
+    } else {
+      setTimeout(() => {
+        window.dispatchEvent(redirectReady);
+        window.lana?.log(
+          'Adobe Analytics done callback failed to trigger, 3 second timeout dispatched event.',
+          { sampleRate: 1, tags: 'DC_Milo,Project Unity (DC)', severity: 'warning' },
+        );
+      }, 3000);
+    }
     setCookie('UTS_Uploaded', Date.now(), cookieExp);
     const calcUploadedTime = uploadedTime();
     const metadata = { ...data, uploadTime: calcUploadedTime, userAttempts: attempts };

--- a/acrobat/blocks/study-marquee/study-marquee.js
+++ b/acrobat/blocks/study-marquee/study-marquee.js
@@ -582,7 +582,7 @@ export default async function init(element) {
   function handleUploadedEvent(data, attempts, cookieExp, canSendDataToSplunk) {
     exitFlag = true;
     if (LIMITS[VERB]?.noRedirectTimeout ?? true) {
-          window.dispatchEvent(redirectReady);
+      window.dispatchEvent(redirectReady);
     } else {
       setTimeout(() => {
         window.dispatchEvent(redirectReady);

--- a/acrobat/blocks/study-marquee/study-marquee.js
+++ b/acrobat/blocks/study-marquee/study-marquee.js
@@ -22,6 +22,7 @@ const ICONS = {
 
 const MB100 = 104857600;
 const STUDY_FILES = ['.pdf', '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx', '.rtf', '.txt', '.text', '.vtt'];
+const STUDY_FILES_EXTENDED = [...STUDY_FILES, '.eml', '.msg', '.jpg', '.jpeg', '.png', '.tif', '.tiff'];
 const STUDY_GENAI = {
   maxFileSize: MB100,
   acceptedFiles: STUDY_FILES,
@@ -32,7 +33,7 @@ const STUDY_GENAI = {
 };
 const STUDY_GENAI_SINGLE = {
   maxFileSize: MB100,
-  acceptedFiles: STUDY_FILES,
+  acceptedFiles: STUDY_FILES_EXTENDED,
   maxNumFiles: 1,
   genAI: true,
 };

--- a/test/blocks/study-marquee/study-marquee.test.js
+++ b/test/blocks/study-marquee/study-marquee.test.js
@@ -99,6 +99,26 @@ describe('study-marquee block', () => {
     expect(document.querySelector('.study-marquee .study-marquee-dropzone')).to.exist;
   });
 
+  it('renders extended accept attribute for gen-presentation-v2 and interactive-report', async () => {
+    const extendedTypes = ['.eml', '.msg', '.jpg', '.jpeg', '.png', '.tif', '.tiff'];
+    const cases = [
+      ['gen-presentation-v2', './mocks/body-gen-presentation-v2.html'],
+      ['interactive-report', './mocks/body-interactive-report.html'],
+    ];
+    for (const [verb, path] of cases) {
+      document.body.innerHTML = await readFile({ path });
+      const block = document.body.querySelector('.study-marquee');
+      const conf = getConfig();
+      setConfig({ ...conf, locale: { prefix: '' } });
+      await init(block);
+      const accept = document.querySelector('.study-marquee #file-upload').getAttribute('accept');
+      const acceptList = accept.split(',');
+      [...extendedTypes, '.pdf', '.docx'].forEach((ext) => {
+        expect(acceptList, `${verb} should accept ${ext}`).to.include(ext);
+      });
+    }
+  });
+
   it('init stylize block', async () => {
     document.body.innerHTML = await readFile({ path: './mocks/body-stylize.html' });
     const block = document.body.querySelector('.study-marquee');

--- a/test/blocks/study-marquee/study-marquee.test.js
+++ b/test/blocks/study-marquee/study-marquee.test.js
@@ -160,6 +160,60 @@ describe('study-marquee block', () => {
     expect(document.querySelector('.study-marquee .study-marquee-dropzone')).to.exist;
   });
 
+  it('dispatches redirect immediately on uploaded when noRedirectTimeout is truthy', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/body-gen-presentation-v2.html' });
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+    const block = document.body.querySelector('.study-marquee');
+    await init(block);
+    await delay(100);
+
+    window.analytics = { verbAnalytics: sinon.spy(), sendAnalyticsToSplunk: sinon.spy() };
+    const redirectSpy = sinon.spy();
+    window.addEventListener('DCUnity:RedirectReady', redirectSpy);
+
+    block.dispatchEvent(new CustomEvent('unity:track-analytics', {
+      detail: { event: 'uploaded', data: {}, sendToSplunk: true },
+    }));
+
+    window.removeEventListener('DCUnity:RedirectReady', redirectSpy);
+    expect(redirectSpy.called).to.be.true;
+    expect(window.analytics.verbAnalytics.calledWith('job:uploaded')).to.be.true;
+  });
+
+  it('delays redirect and logs a warning on uploaded when noRedirectTimeout is false', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/body-gen-presentation-v2.html' });
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+    const block = document.body.querySelector('.study-marquee');
+    await init(block);
+    await delay(100);
+
+    window.analytics = { verbAnalytics: sinon.spy(), sendAnalyticsToSplunk: sinon.spy() };
+    const original = LIMITS['gen-presentation-v2'].noRedirectTimeout;
+    LIMITS['gen-presentation-v2'].noRedirectTimeout = false;
+    const clock = sinon.useFakeTimers();
+    const redirectSpy = sinon.spy();
+    window.addEventListener('DCUnity:RedirectReady', redirectSpy);
+
+    try {
+      block.dispatchEvent(new CustomEvent('unity:track-analytics', {
+        detail: { event: 'uploaded', data: {}, sendToSplunk: true },
+      }));
+
+      // Redirect is deferred until the 3 second fallback timeout elapses.
+      expect(redirectSpy.called).to.be.false;
+      clock.tick(3000);
+      expect(redirectSpy.called).to.be.true;
+      expect(window.lana.log.calledWith(sinon.match(/3 second timeout dispatched event/))).to.be.true;
+    } finally {
+      clock.restore();
+      window.removeEventListener('DCUnity:RedirectReady', redirectSpy);
+      if (original === undefined) delete LIMITS['gen-presentation-v2'].noRedirectTimeout;
+      else LIMITS['gen-presentation-v2'].noRedirectTimeout = original;
+    }
+  });
+
   it('show error toast', async () => {
     const conf = getConfig();
     setConfig({ ...conf, locale: { prefix: '' } });

--- a/test/blocks/study-marquee/study-marquee.test.js
+++ b/test/blocks/study-marquee/study-marquee.test.js
@@ -172,9 +172,7 @@ describe('study-marquee block', () => {
     const redirectSpy = sinon.spy();
     window.addEventListener('DCUnity:RedirectReady', redirectSpy);
 
-    block.dispatchEvent(new CustomEvent('unity:track-analytics', {
-      detail: { event: 'uploaded', data: {}, sendToSplunk: true },
-    }));
+    block.dispatchEvent(new CustomEvent('unity:track-analytics', { detail: { event: 'uploaded', data: {}, sendToSplunk: true } }));
 
     window.removeEventListener('DCUnity:RedirectReady', redirectSpy);
     expect(redirectSpy.called).to.be.true;
@@ -197,9 +195,7 @@ describe('study-marquee block', () => {
     window.addEventListener('DCUnity:RedirectReady', redirectSpy);
 
     try {
-      block.dispatchEvent(new CustomEvent('unity:track-analytics', {
-        detail: { event: 'uploaded', data: {}, sendToSplunk: true },
-      }));
+      block.dispatchEvent(new CustomEvent('unity:track-analytics', { detail: { event: 'uploaded', data: {}, sendToSplunk: true } }));
 
       // Redirect is deferred until the 3 second fallback timeout elapses.
       expect(redirectSpy.called).to.be.false;

--- a/test/blocks/study-marquee/study-marquee.test.js
+++ b/test/blocks/study-marquee/study-marquee.test.js
@@ -58,7 +58,11 @@ describe('study-marquee block', () => {
     expect(LIMITS).to.have.property('interactive-report');
     ['gen-presentation-v2', 'interactive-report'].forEach((verb) => {
       expect(LIMITS[verb].acceptedFiles).to.be.an('array');
-      expect(LIMITS[verb].acceptedFiles).to.deep.equal(LIMITS['flashcard-maker'].acceptedFiles);
+      // Extends the base study file types with email and image formats.
+      expect(LIMITS[verb].acceptedFiles).to.include.members(LIMITS['flashcard-maker'].acceptedFiles);
+      ['.eml', '.msg', '.jpg', '.jpeg', '.png', '.tif', '.tiff'].forEach((ext) => {
+        expect(LIMITS[verb].acceptedFiles).to.include(ext);
+      });
       expect(LIMITS[verb].maxFileSize).to.equal(104857600);
       expect(LIMITS[verb].maxNumFiles).to.equal(1);
       expect(LIMITS[verb].multipleFiles).to.not.be.ok;

--- a/test/blocks/verb-redesign-test/mocks/body-jpg-to-pdf-challenger1.html
+++ b/test/blocks/verb-redesign-test/mocks/body-jpg-to-pdf-challenger1.html
@@ -1,0 +1,17 @@
+<main>
+  <div>
+    <div class="verb-redesign-test jpg-to-pdf challenger1">
+      <div>
+        <div>
+          <h1 id="jpg-to-pdf">Convert JPG to PDF</h1>
+        </div>
+        <div>
+          <picture>
+            <img loading="lazy" alt="" src="./media_foreground.png" width="800" height="600">
+          </picture>
+        </div>
+      </div>
+    </div>
+    <div class="unity workflow-acrobat"></div>
+  </div>
+</main>

--- a/test/blocks/verb-redesign-test/mocks/body-word-to-pdf.html
+++ b/test/blocks/verb-redesign-test/mocks/body-word-to-pdf.html
@@ -1,0 +1,27 @@
+<main>
+  <div>
+    <div class="verb-redesign-test word-to-pdf">
+      <div>
+        <picture>
+          <source type="image/webp" srcset="./media_background.png" media="(min-width: 600px)">
+          <img loading="lazy" alt="" src="./media_background.png" width="2000" height="1200">
+        </picture>
+      </div>
+      <div>
+        <div>
+          <h1 id="word-to-pdf">Convert Word to PDF</h1>
+        </div>
+        <div>
+          <picture>
+            <source type="image/webp" srcset="./media_foreground.png" media="(min-width: 600px)">
+            <img loading="lazy" alt="" src="./media_foreground.png" width="800" height="600">
+          </picture>
+        </div>
+        <div>
+          <a href="#upload">Select a file</a>
+        </div>
+      </div>
+    </div>
+    <div class="unity workflow-acrobat"></div>
+  </div>
+</main>

--- a/test/blocks/verb-redesign-test/mocks/head.html
+++ b/test/blocks/verb-redesign-test/mocks/head.html
@@ -1,0 +1,3 @@
+<link rel="icon" href="data:,">
+<link rel="stylesheet" href="/acrobat/styles/styles.css" />
+<link rel="stylesheet" href="/acrobat/blocks/verb-redesign-test/verb-redesign-test.css" />

--- a/test/blocks/verb-redesign-test/mocks/placeholders.json
+++ b/test/blocks/verb-redesign-test/mocks/placeholders.json
@@ -1,0 +1,51 @@
+{
+  "total": 10,
+  "offset": 0,
+  "limit": 10,
+  "data": [
+    {
+      "key": "verb-redesign-test-cta",
+      "value": "Select a file"
+    },
+    {
+      "key": "verb-redesign-test-word-to-pdf-subtitle",
+      "value": "Convert Word files to PDF."
+    },
+    {
+      "key": "verb-redesign-test-word-to-pdf-dragndrop-text",
+      "value": "or drag and drop a file"
+    },
+    {
+      "key": "verb-redesign-test-word-to-pdf-file-limit",
+      "value": "Max file size 100MB."
+    },
+    {
+      "key": "verb-redesign-test-highlight-1",
+      "value": "Fast and easy"
+    },
+    {
+      "key": "verb-redesign-test-highlight-2",
+      "value": "Secure"
+    },
+    {
+      "key": "verb-redesign-test-highlight-3",
+      "value": "Files deleted automatically"
+    },
+    {
+      "key": "verb-redesign-test-legal",
+      "value": "By using this service you agree to the Terms of Use and Privacy Policy."
+    },
+    {
+      "key": "verb-widget-terms-of-use",
+      "value": "Terms of Use"
+    },
+    {
+      "key": "verb-widget-privacy-policy",
+      "value": "Privacy Policy"
+    },
+    {
+      "key": "verb-widget-tool-tip",
+      "value": "Your files are secure."
+    }
+  ]
+}

--- a/test/blocks/verb-redesign-test/verb-redesign-test.test.js
+++ b/test/blocks/verb-redesign-test/verb-redesign-test.test.js
@@ -1,0 +1,255 @@
+/* eslint-disable compat/compat */
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { delay } from '../../helpers/waitfor.js';
+import { getConfig, setConfig } from 'https://main--milo--adobecom.aem.live/libs/utils/utils.js'; // eslint-disable-line import/no-unresolved, import/order
+
+const { default: init, LIMITS } = await import(
+  '../../../acrobat/blocks/verb-redesign-test/verb-redesign-test.js'
+);
+
+const dispatchTrack = (block, event, detail = {}) => {
+  block.dispatchEvent(new CustomEvent('unity:track-analytics', { detail: { event, data: {}, sendToSplunk: true, ...detail } }));
+};
+
+describe('verb-redesign-test block', () => {
+  let xhr;
+  let placeholders;
+
+  beforeEach(async () => {
+    sinon.stub(window, 'fetch');
+    window.fetch.callsFake((x) => {
+      if (x.endsWith('.svg')) {
+        return window.fetch.wrappedMethod.call(window, x);
+      }
+      return Promise.resolve();
+    });
+    const placeholdersText = await readFile({ path: './mocks/placeholders.json' });
+    placeholders = JSON.parse(placeholdersText);
+
+    window.mph = {};
+    placeholders.data.forEach((item) => {
+      window.mph[item.key] = item.value;
+    });
+    xhr = sinon.useFakeXMLHttpRequest();
+    document.head.innerHTML = await readFile({ path: './mocks/head.html' });
+    document.body.innerHTML = await readFile({ path: './mocks/body-word-to-pdf.html' });
+    window.adobeIMS = { isSignedInUser: () => false };
+    window.lana = { log: sinon.spy() };
+  });
+
+  afterEach(() => {
+    xhr.restore();
+    sinon.restore();
+  });
+
+  it('exports LIMITS for jpg-to-pdf and word-to-pdf', () => {
+    expect(LIMITS).to.have.property('jpg-to-pdf');
+    expect(LIMITS).to.have.property('word-to-pdf');
+    ['jpg-to-pdf', 'word-to-pdf'].forEach((verb) => {
+      expect(LIMITS[verb].acceptedFiles).to.be.an('array');
+      expect(LIMITS[verb].acceptedFiles).to.include('.pdf');
+      expect(LIMITS[verb].maxFileSize).to.equal(104857600);
+      expect(LIMITS[verb].multipleFiles).to.be.true;
+      expect(LIMITS[verb].noRedirectTimeout).to.be.true;
+    });
+  });
+
+  it('init word-to-pdf block renders header, dropzone and file input', async () => {
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+    const block = document.body.querySelector('.verb-redesign-test');
+    await init(block);
+
+    expect(block.classList.contains('con-block')).to.be.true;
+    expect(document.querySelector('.verb-redesign-test .vm2-heading')).to.exist;
+    expect(document.querySelector('.verb-redesign-test .vm2-dropzone')).to.exist;
+    const fileInput = document.querySelector('.verb-redesign-test #file-upload');
+    expect(fileInput).to.exist;
+    expect(fileInput.getAttribute('accept').split(',')).to.include('.pdf');
+    // Placeholders drive benefits, legal links and tooltip.
+    expect(document.querySelector('.verb-redesign-test .vm2-benefits')).to.exist;
+    expect(document.querySelector('.verb-redesign-test .vm2-legal-url')).to.exist;
+    expect(document.querySelector('.verb-redesign-test .info-icon svg')).to.exist;
+  });
+
+  it('init challenger1 variant lays out text columns', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/body-jpg-to-pdf-challenger1.html' });
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+    const block = document.body.querySelector('.verb-redesign-test');
+    await init(block);
+
+    expect(block.classList.contains('challenger1')).to.be.true;
+    expect(document.querySelector('.verb-redesign-test .vm2-text-col')).to.exist;
+    expect(document.querySelector('.verb-redesign-test .vm2-text-top')).to.exist;
+    expect(document.querySelector('.verb-redesign-test .vm2-text-bottom')).to.exist;
+  });
+
+  it('handles unity:track-analytics events without throwing', async () => {
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+    const block = document.body.querySelector('.verb-redesign-test');
+    await init(block);
+    await delay(100);
+
+    window.analytics = { verbAnalytics: sinon.spy(), sendAnalyticsToSplunk: sinon.spy() };
+
+    dispatchTrack(block, 'change');
+    dispatchTrack(block, 'drop');
+    dispatchTrack(block, 'cancel');
+    dispatchTrack(block, 'uploading', { sendToSplunk: false });
+    dispatchTrack(block, 'uploaded');
+    dispatchTrack(block, 'chunk_uploaded');
+    dispatchTrack(block, 'redirectUrl', { data: { redirectUrl: 'https://example.com/next' } });
+
+    expect(window.analytics.verbAnalytics.called).to.be.true;
+    expect(window.analytics.sendAnalyticsToSplunk.called).to.be.true;
+    expect(window.analytics.verbAnalytics.calledWith('job:uploaded')).to.be.true;
+
+    expect(() => dispatchTrack(block, 'unknown')).to.not.throw();
+    // Missing event is ignored.
+    expect(() => block.dispatchEvent(new CustomEvent('unity:track-analytics', { detail: {} }))).to.not.throw();
+  });
+
+  it('dispatches redirect immediately on uploaded when noRedirectTimeout is truthy', async () => {
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+    const block = document.body.querySelector('.verb-redesign-test');
+    await init(block);
+    await delay(100);
+
+    window.analytics = { verbAnalytics: sinon.spy(), sendAnalyticsToSplunk: sinon.spy() };
+    const redirectSpy = sinon.spy();
+    window.addEventListener('DCUnity:RedirectReady', redirectSpy);
+
+    dispatchTrack(block, 'uploaded');
+
+    window.removeEventListener('DCUnity:RedirectReady', redirectSpy);
+    expect(redirectSpy.called).to.be.true;
+  });
+
+  it('delays redirect and logs a warning on uploaded when noRedirectTimeout is false', async () => {
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+    const block = document.body.querySelector('.verb-redesign-test');
+    await init(block);
+    await delay(100);
+
+    window.analytics = { verbAnalytics: sinon.spy(), sendAnalyticsToSplunk: sinon.spy() };
+    const original = LIMITS['word-to-pdf'].noRedirectTimeout;
+    LIMITS['word-to-pdf'].noRedirectTimeout = false;
+    const clock = sinon.useFakeTimers();
+    const redirectSpy = sinon.spy();
+    window.addEventListener('DCUnity:RedirectReady', redirectSpy);
+
+    try {
+      dispatchTrack(block, 'uploaded');
+      expect(redirectSpy.called).to.be.false;
+      clock.tick(3000);
+      expect(redirectSpy.called).to.be.true;
+      expect(window.lana.log.calledWith(sinon.match(/3 second timeout dispatched event/))).to.be.true;
+    } finally {
+      clock.restore();
+      window.removeEventListener('DCUnity:RedirectReady', redirectSpy);
+      if (original === undefined) delete LIMITS['word-to-pdf'].noRedirectTimeout;
+      else LIMITS['word-to-pdf'].noRedirectTimeout = original;
+    }
+  });
+
+  it('shows an error toast and maps the error to analytics', async () => {
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+    const block = document.body.querySelector('.verb-redesign-test');
+    await init(block);
+    await delay(100);
+
+    window.analytics = { verbAnalytics: sinon.spy(), sendAnalyticsToSplunk: sinon.spy() };
+
+    block.dispatchEvent(new CustomEvent('unity:show-error-toast', {
+      detail: {
+        code: 'error_unsupported_type',
+        info: 'Test error info',
+        metaData: 'metadata',
+        errorData: 'errorData',
+        sendToSplunk: true,
+        message: 'This file type is not supported.',
+      },
+    }));
+
+    const errorState = block.querySelector('.error');
+    expect(errorState.classList.contains('hide')).to.be.false;
+    expect(block.querySelector('.vm2-error-text').textContent).to.equal('This file type is not supported.');
+    expect(window.analytics.verbAnalytics.calledWith('error:UnsupportedFile')).to.be.true;
+    expect(window.analytics.sendAnalyticsToSplunk.called).to.be.true;
+    expect(window.lana.log.called).to.be.true;
+  });
+
+  it('ignores an error toast with no code and returns early on cookie_not_set', async () => {
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+    const block = document.body.querySelector('.verb-redesign-test');
+    await init(block);
+    await delay(100);
+
+    window.analytics = { verbAnalytics: sinon.spy(), sendAnalyticsToSplunk: sinon.spy() };
+
+    block.dispatchEvent(new CustomEvent('unity:show-error-toast', { detail: {} }));
+    block.dispatchEvent(new CustomEvent('unity:show-error-toast', { detail: { code: 'cookie_not_set', message: 'ignored' } }));
+
+    expect(window.analytics.verbAnalytics.called).to.be.false;
+  });
+
+  it('closes the error toast when the close button is clicked', async () => {
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+    const block = document.body.querySelector('.verb-redesign-test');
+    await init(block);
+    await delay(100);
+
+    window.analytics = { verbAnalytics: sinon.spy(), sendAnalyticsToSplunk: sinon.spy() };
+    block.dispatchEvent(new CustomEvent('unity:show-error-toast', { detail: { code: 'error_generic', message: 'Test error', sendToSplunk: false } }));
+
+    const errorState = block.querySelector('.error');
+    expect(errorState.classList.contains('hide')).to.be.false;
+    block.querySelector('.vm2-error-btn').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(errorState.classList.contains('hide')).to.be.true;
+  });
+
+  it('opens the file picker when the cta is clicked', async () => {
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+    const block = document.body.querySelector('.verb-redesign-test');
+    await init(block);
+
+    const fileInput = block.querySelector('#file-upload');
+    const clickSpy = sinon.spy(fileInput, 'click');
+    block.querySelector('.vm2-cta').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(clickSpy.called).to.be.true;
+  });
+
+  it('tracks a drop of files onto the block', async () => {
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+    const block = document.body.querySelector('.verb-redesign-test');
+    await init(block);
+
+    const dataTransfer = new DataTransfer();
+    const dropEvent = new DragEvent('drop', { bubbles: true, cancelable: true, dataTransfer });
+    expect(() => block.dispatchEvent(dropEvent)).to.not.throw();
+    expect(block.classList.contains('dragging-block')).to.be.false;
+  });
+
+  it('handles a signed-in user without an account type', async () => {
+    window.adobeIMS = {
+      isSignedInUser: () => true,
+      getAccountType: () => '',
+    };
+    const conf = getConfig();
+    setConfig({ ...conf, locale: { prefix: '' } });
+    const block = document.body.querySelector('.verb-redesign-test');
+    await init(block);
+    expect(document.querySelector('.verb-redesign-test .vm2-heading')).to.exist;
+  });
+});

--- a/test/blocks/verb-widget-client-upload/verb-widget-client-upload.test.js
+++ b/test/blocks/verb-widget-client-upload/verb-widget-client-upload.test.js
@@ -1,0 +1,147 @@
+/* eslint-disable compat/compat */
+import { expect } from '@esm-bundle/chai';
+
+const {
+  validateFiles,
+  encryptAndStore,
+  storeEncryptedLocalFile,
+  openIDB,
+  IDB_NAME,
+  IDB_STORE,
+} = await import(
+  '../../../acrobat/blocks/verb-widget-client-upload/verb-widget-client-upload.js'
+);
+
+const VERB = 'image-to-pdf';
+
+function makeFile(bytes, name, type) {
+  return new File([bytes], name, { type });
+}
+
+function readRecord(id) {
+  return openIDB().then((db) => new Promise((resolve, reject) => {
+    const tx = db.transaction(IDB_STORE, 'readonly');
+    const req = tx.objectStore(IDB_STORE).get(id);
+    req.onsuccess = () => { resolve(req.result); db.close(); };
+    req.onerror = ({ target: { error } }) => { reject(error); db.close(); };
+  }));
+}
+
+function deleteDB() {
+  return new Promise((resolve) => {
+    const req = indexedDB.deleteDatabase(IDB_NAME);
+    req.onsuccess = resolve;
+    req.onerror = resolve;
+    req.onblocked = resolve;
+  });
+}
+
+describe('verb-widget-client-upload', () => {
+  beforeEach(() => {
+    window.mph = {};
+  });
+
+  afterEach(async () => {
+    await deleteDB();
+  });
+
+  describe('validateFiles', () => {
+    it('accepts a valid single image', () => {
+      const file = makeFile(new Uint8Array([1, 2, 3]), 'photo.jpg', 'image/jpeg');
+      expect(validateFiles([file], VERB)).to.deep.equal({ valid: true });
+    });
+
+    it('accepts png by extension and mime', () => {
+      const file = makeFile(new Uint8Array([1]), 'photo.png', 'image/png');
+      expect(validateFiles([file], VERB).valid).to.be.true;
+    });
+
+    it('rejects an unknown verb', () => {
+      const file = makeFile(new Uint8Array([1]), 'photo.jpg', 'image/jpeg');
+      expect(validateFiles([file], 'not-a-verb')).to.include({ valid: false, code: 'error_generic' });
+    });
+
+    it('rejects when no files are provided', () => {
+      expect(validateFiles([], VERB)).to.include({ valid: false, code: 'error_generic' });
+    });
+
+    it('rejects more than one file (single-file tool)', () => {
+      const a = makeFile(new Uint8Array([1]), 'a.jpg', 'image/jpeg');
+      const b = makeFile(new Uint8Array([1]), 'b.jpg', 'image/jpeg');
+      expect(validateFiles([a, b], VERB)).to.include({ valid: false, code: 'error_only_accept_one_file' });
+    });
+
+    it('rejects an empty file', () => {
+      const file = makeFile(new Uint8Array([]), 'empty.jpg', 'image/jpeg');
+      expect(validateFiles([file], VERB)).to.include({ valid: false, code: 'error_empty_file' });
+    });
+
+    it('rejects a file over the 25 MB limit', () => {
+      const tooBig = { name: 'huge.jpg', type: 'image/jpeg', size: 26214400 + 1 };
+      expect(validateFiles([tooBig], VERB)).to.include({ valid: false, code: 'error_file_too_large' });
+    });
+
+    it('rejects an unsupported extension', () => {
+      const file = makeFile(new Uint8Array([1]), 'doc.pdf', 'application/pdf');
+      expect(validateFiles([file], VERB)).to.include({ valid: false, code: 'error_unsupported_type' });
+    });
+
+    it('rejects a mismatched mime type for a supported extension', () => {
+      const file = makeFile(new Uint8Array([1]), 'photo.jpg', 'application/pdf');
+      expect(validateFiles([file], VERB)).to.include({ valid: false, code: 'error_unsupported_type' });
+    });
+  });
+
+  describe('storeEncryptedLocalFile', () => {
+    it('stores an encrypted record whose ciphertext decrypts back to the original bytes', async () => {
+      const original = new Uint8Array([10, 20, 30, 40, 50]);
+      const file = makeFile(original, 'photo.jpg', 'image/jpeg');
+      const id = 'test-id-1';
+
+      await storeEncryptedLocalFile(id, file);
+      const record = await readRecord(id);
+
+      expect(record).to.exist;
+      expect(record.fileName).to.equal('photo.jpg');
+      expect(record.mimeType).to.equal('image/jpeg');
+      expect(record.iv).to.be.instanceOf(Uint8Array);
+      expect(record.iv.length).to.equal(12);
+      expect(record.key).to.be.instanceOf(CryptoKey);
+      // The stored bytes must not be the plaintext.
+      expect(new Uint8Array(record.ciphertext)).to.not.deep.equal(original);
+
+      const decrypted = await crypto.subtle.decrypt(
+        { name: 'AES-GCM', iv: record.iv },
+        record.key,
+        record.ciphertext,
+      );
+      expect(new Uint8Array(decrypted)).to.deep.equal(original);
+    });
+  });
+
+  describe('encryptAndStore', () => {
+    it('returns a UUID and persists a matching record', async () => {
+      const file = makeFile(new Uint8Array([1, 2, 3, 4]), 'photo.png', 'image/png');
+      const id = await encryptAndStore(file);
+
+      expect(id).to.match(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+      );
+      const record = await readRecord(id);
+      expect(record).to.exist;
+      expect(record.fileName).to.equal('photo.png');
+    });
+
+    it('produces a unique id and a unique key per call', async () => {
+      const file = makeFile(new Uint8Array([9, 9, 9]), 'photo.jpg', 'image/jpeg');
+      const id1 = await encryptAndStore(file);
+      const id2 = await encryptAndStore(file);
+      expect(id1).to.not.equal(id2);
+
+      const [r1, r2] = await Promise.all([readRecord(id1), readRecord(id2)]);
+      expect(r1.key).to.not.equal(r2.key);
+      // Random IV per file means identical plaintext yields different ciphertext.
+      expect(new Uint8Array(r1.ciphertext)).to.not.deep.equal(new Uint8Array(r2.ciphertext));
+    });
+  });
+});


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
* Update supported file for gen presentation and interactive report verbs
* Also removed 3 second wait from all the student space verbs for uploaded analytics same as verb-widget.js block
* Added more unit test to the project to increase code coverage


## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-205598](https://jira.corp.adobe.com/browse/MWPW-205598)

## Test URLs
<!-- List the URLs where the changes can be tested -->
- https://stage--da-dc--adobecom.aem.page/acrobat/campaign/generate-presentation
- https://MWPW-205598--da-dc--adobecom.aem.page/acrobat/campaign/generate-presentation

- https://stage--da-dc--adobecom.aem.page/acrobat/campaign/interactive-report
- https://MWPW-205598--da-dc--adobecom.aem.page/acrobat/campaign/interactive-report
