### PR TITLE
[MWPW-205643]Remove 3 second wait from analytics event uploaded from verb-marquee and verb-redisign-test block

### DIFF
--- a/acrobat/blocks/verb-marquee/verb-marquee.js
+++ b/acrobat/blocks/verb-marquee/verb-marquee.js
@@ -684,7 +684,7 @@ export default async function init(element) {
 
   function handleUploadedEvent(data, attempts, cookieExp, canSendDataToSplunk) {
     exitFlag = true;
-    if (LIMITS[VERB]?.noRedirectTimeout) {
+    if (LIMITS[VERB]?.noRedirectTimeout ?? true) {
       window.dispatchEvent(redirectReady);
     } else {
       setTimeout(() => {

--- a/acrobat/blocks/verb-redesign-test/verb-redesign-test.js
+++ b/acrobat/blocks/verb-redesign-test/verb-redesign-test.js
@@ -583,7 +583,7 @@ export default async function init(element) {
 
   function handleUploadedEvent(data, attempts, cookieExp, canSendDataToSplunk) {
     exitFlag = true;
-    if (LIMITS[VERB]?.noRedirectTimeout) {
+    if (LIMITS[VERB]?.noRedirectTimeout ?? true) {
       window.dispatchEvent(redirectReady);
     } else {
       setTimeout(() => {


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Remove 3 second wait from analytics event uploaded from following blocks
* verb-marquee
* verb-redesign-test

## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-205643](https://jira.corp.adobe.com/browse/MWPW-205643)

## Test URLs
<!-- List the URLs where the changes can be tested -->
- https://main--da-dc--adobecom.aem.live/acrobat/online/ai-resume-builder
- https://MWPW-205643--da-dc--adobecom.aem.live/acrobat/online/ai-resume-builder

Note: Similar change has already been implemented for verb-widget block https://github.com/adobecom/da-dc/pull/150/changes
